### PR TITLE
Fixing typescript to newest version pre 1.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "gulp": "latest",
         "typescript": "1.5.3",
         "gulp-json-editor": "latest",
-        "gulp-typescript": "latest",
+        "gulp-typescript": "2.8.3",
         "gulp-sourcemaps": "latest",
         "merge2": "latest",
         "ncp": "latest",


### PR DESCRIPTION
If we try to build with the latest typescript (1.6.2 at the moment) we hit some errors due to changes in object literal types. We should fix up the core issues, but to build the initial release we can just continue using the previous version of typescript.
