### PR TITLE
Fix Git templates copy bug

### DIFF
--- a/src/taco-cli/cli/utils/templateManager.ts
+++ b/src/taco-cli/cli/utils/templateManager.ts
@@ -106,20 +106,33 @@ class TemplateManager {
                 return cordovaWrapper.create(cordovaCliVersion, cordovaParameters);
             })
             .then(function (): Q.Promise<any> {
-                // If there is no "www" folder at the root of the template, it means Cordova already copied everything to [project]\www\
-                var skipCopy: boolean = !fs.readdirSync(templateSrcPath).some(function (itemPath: string): boolean {
-                    if (path.basename(itemPath) === "www") {
-                        return true;
-                    }
+                /*
+                Cordova's --copy-from behavior: "cordova create [project path] --copy-from [template path]" supports 2 scenarios: 1) The template is for the entire project; 2) The template is only
+                for the www assets.
 
-                    return false;
+                Cordova looks for a "www" folder at the root of the specified path ("the template"). If it finds one, then it assumes we are in case 1), otherwise it assumes we are in case 2).
+
+                For case 1), Cordova looks for 4 specific items at the root of the template: "config.xml", "www\", "merges\" and "hooks\". When it finds one of those items, Cordova copies it to the
+                user's project, otherwise it uses the default for that particular item. It ignores everything else in the template.
+
+                For case 2), Cordova copies everything it finds in the template over to the "www\" folder of the user's project, and uses default items for everything else ("config.xml", "merges\",
+                etc).
+
+                What this means for TACO project creation: If we are in case 1), we need to copy the template items that Cordova ignored. For simplicity, we will simply recursively copy the entire
+                template folder to the user's project, while using the "clobber = false" option of the NCP package. That way, all the items get copied over, but those that were already copied by
+                Cordova are ignored. If we are in case 2), it means we don't have anything to do, because Cordova already copied all the template items to the "www\" folder of the user's project.
+                */
+
+                // If we are in case 2) (see above comment), we need to skip the copy step
+                var skipCopy: boolean = !fs.readdirSync(templateSrcPath).some(function (itemPath: string): boolean {
+                    return path.basename(itemPath) === "www";
                 });
 
                 if (skipCopy) {
                     return Q.resolve({});
                 }
 
-                // If we reach this point, it means there is a "www" folder at the root of the template; we need to perform a recursive copy from the template to the project
+                // If we reach this point, we are in case 1) (see above comment), so we need to perform a recursive copy
                 var filterFunc = function (itemPath: string): boolean {
                     // Return true if the item path is not in our list of git files to ignore
                     return TemplateManager.GitFileList.indexOf(path.basename(itemPath)) === -1;


### PR DESCRIPTION
Right now, when you create a project using a git template that does not have a "www" folder at its root, the template items end up in the project twice: once at the root, and once under www/. This PR is to fix that issue. We no longer copy template items if the template doesn't have a "www" folder at its root, because that means Cordova will have already copied everything to the project, under www/.
