### PR TITLE
Addressing test failure on MAC

### DIFF
--- a/src/taco-cli/test/platformPlugin.ts
+++ b/src/taco-cli/test/platformPlugin.ts
@@ -123,7 +123,7 @@ var kitPlatformOperations: ICommandAndResult[] = [
         
 var cliPlatformOperations: ICommandAndResult[] = [ 
         {   
-            command: "add android windows", 
+            command: "add android browser", 
             expectedVersions: cliPlatformVersions,
             expectedTelemetryProperties: {
                     cli: { isPii: false, value: "5.0.0" },
@@ -132,11 +132,11 @@ var cliPlatformOperations: ICommandAndResult[] = [
                     projectType: { isPii: false, value: "JavaScript" },
                     subCommand: { isPii: false, value: "add" },
                     target1: { isPii: false, value: "android" },
-                    target2: { isPii: false, value: "windows" }
+                    target2: { isPii: false, value: "browser" }
             }
         },
         {   
-            command: "remove android windows", 
+            command: "remove android browser", 
             expectedVersions: {}, 
             expectedTelemetryProperties: {
                 cli: { isPii: false, value: "5.0.0" },
@@ -145,12 +145,12 @@ var cliPlatformOperations: ICommandAndResult[] = [
                 projectType: { isPii: false, value: "JavaScript" },        
                 subCommand: { isPii: false, value: "remove" },
                 target1: { isPii: false, value: "android" },
-                target2: { isPii: false, value: "windows" }
+                target2: { isPii: false, value: "browser" }
             }
         },
 
         {   
-            command: "add android@4.0.1 windows@4.0.0", 
+            command: "add android@4.0.1 browser@4.0.0", 
             expectedVersions: userOverridePlatformVersions, 
             expectedTelemetryProperties: {
                 cli: { isPii: false, value: "5.0.0" },
@@ -159,11 +159,11 @@ var cliPlatformOperations: ICommandAndResult[] = [
                 projectType: { isPii: false, value: "JavaScript" },   
                 subCommand: { isPii: false, value: "add" },
                 target1: { isPii: false, value: "android@4.0.1" },
-                target2: { isPii: false, value: "windows@4.0.0" } 
+                target2: { isPii: false, value: "browser@4.0.0" } 
             }
         },
         {   
-            command: "remove android windows", 
+            command: "remove android browser", 
             expectedVersions: {}, 
             expectedTelemetryProperties: {
                 cli: { isPii: false, value: "5.0.0" },
@@ -172,7 +172,7 @@ var cliPlatformOperations: ICommandAndResult[] = [
                 projectType: { isPii: false, value: "JavaScript" },   
                 subCommand: { isPii: false, value: "remove" },
                 target1: { isPii: false, value: "android" },
-                target2: { isPii: false, value: "windows" } 
+                target2: { isPii: false, value: "browser" } 
             }
         }
     ];


### PR DESCRIPTION
Use browser platform instead of windows to circumvent test failure on MAC
