### PR TITLE
Fixing identification of certificate issues

### DIFF
--- a/src/taco-cli/cli/remote.ts
+++ b/src/taco-cli/cli/remote.ts
@@ -352,7 +352,9 @@ class Remote extends commands.TacoCommandBase {
     }
 
     private static getFriendlyHttpError(error: any, host: string, port: number, url: string, secure: boolean): Error {
-        if (error.code === "ECONNREFUSED") {
+        if (error.code.indexOf("CERT_") !== -1) {
+            return errorHelper.get(TacoErrorCodes.InvalidRemoteBuildClientCert);
+        } else if (error.code === "ECONNREFUSED") {
             return errorHelper.get(TacoErrorCodes.CommandRemoteConnectionRefused, util.format("%s://%s:%s", secure ? "https" : "http", host, port));
         } else if (error.code === "ENOTFOUND") {
             return errorHelper.get(TacoErrorCodes.CommandRemoteNotfound, host);

--- a/src/taco-cli/cli/remoteBuild/remoteBuildClientHelper.ts
+++ b/src/taco-cli/cli/remoteBuild/remoteBuildClientHelper.ts
@@ -232,7 +232,7 @@ class RemoteBuildClientHelper {
      * Convert errors from error codes to localizable strings
      */
     private static errorFromRemoteBuildServer(serverUrl: string, requestError: any, fallbackErrorCode: TacoErrorCodes): Error {
-        if (requestError.toString().indexOf("CERT_") !== -1) {
+        if (requestError.code.indexOf("CERT_") !== -1) {
             return errorHelper.get(TacoErrorCodes.InvalidRemoteBuildClientCert);
         } else if (serverUrl.indexOf("https://") === 0 && requestError.code === "ECONNRESET") {
             return errorHelper.get(TacoErrorCodes.RemoteBuildSslConnectionReset, serverUrl);


### PR DESCRIPTION
We were checking the wrong condition (or not checking at all) for certificate related issues. With this change we now look at the correct condition and report the intended message.
