### PR TITLE
Remove [COMMAND] from taco help feedback

### DIFF
--- a/src/taco-cli/cli/commands.json
+++ b/src/taco-cli/cli/commands.json
@@ -492,7 +492,7 @@
         },
         "feedback":
         {
-            "synopsis": "<synopsis>[COMMAND]</synopsis>",
+            "synopsis": "<synopsis></synopsis>",
             "categoryTitle": "[GeneralCommandsTitle]",
             "modulePath": "./feedback",
             "description": "<helptitle>[CommandFeedbackDescription]</helptitle>"


### PR DESCRIPTION
- The feedback command doesn't take any parameters. Fixing the help to match that.
