### PR TITLE
Adding missed validated plugin cordova-file-transfer

### DIFF
--- a/src/taco-kits/TacoKitMetaData.json
+++ b/src/taco-kits/TacoKitMetaData.json
@@ -90,6 +90,9 @@
                 "cordova-plugin-file": {
                     "version": "3.0.0"
                 },
+                "cordova-plugin-file-transfer": {
+                    "version": "1.2.1"
+                },
                 "cordova-plugin-inappbrowser": {
                     "version": "1.0.1"
                 },


### PR DESCRIPTION
Updating the Cordova 5.2.0 kit to contain version 1.2.1 of the file transfer plugin.