### PR TITLE
Fixed adb not being found on Darwin for Android SDK installation

### DIFF
--- a/src/taco-dependency-installer/installers/androidSdkInstaller.ts
+++ b/src/taco-dependency-installer/installers/androidSdkInstaller.ts
@@ -222,7 +222,7 @@ class AndroidSdkInstaller extends InstallerBase {
         // can result in a hang post installation
         var deferred: Q.Deferred<any> = Q.defer<any>();
 
-        var adbProcess: childProcess.ChildProcess = childProcess.spawn("adb", ["kill-server"]);
+        var adbProcess: childProcess.ChildProcess = childProcess.spawn(path.join(this.androidHomeValue, "platform-tools", "adb"), ["kill-server"]);
         adbProcess.on("error", function (error: Error): void {
             this.telemetry
                 .add("error.description", "ErrorOnKillingAdb in killAdb", /*isPii*/ false)


### PR DESCRIPTION
We invoke "adb kill-server" after Android SDK installation to make sure the installer process exists. However, on fresh Mac machines, adb isn't found and that causes an error to be thrown.
