### PR TITLE
Fixed a telemetry bug, which caused telemetry code to crash during install-reqs

### DIFF
--- a/src/taco-dependency-installer/installers/androidSdkInstaller.ts
+++ b/src/taco-dependency-installer/installers/androidSdkInstaller.ts
@@ -132,7 +132,7 @@ class AndroidSdkInstaller extends InstallerBase {
 
         this.androidHomeValue = androidHomeValue;
 
-        childProcess.exec(updateCommand, function (error: Error, stdout: Buffer, stderr: Buffer): void {
+        childProcess.exec(updateCommand, (error: Error, stdout: Buffer, stderr: Buffer) => {
             if (error) {
                 this.telemetry
                     .add("error.description", "ErrorOnChildProcess on updateVariablesDarwin", /*isPii*/ false)
@@ -202,7 +202,7 @@ class AndroidSdkInstaller extends InstallerBase {
         var deferred: Q.Deferred<any> = Q.defer<any>();
         var command: string = "chmod a+x " + path.join(this.androidHomeValue, "tools", "android");
 
-        childProcess.exec(command, function (error: Error, stdout: Buffer, stderr: Buffer): void {
+        childProcess.exec(command, (error: Error, stdout: Buffer, stderr: Buffer) => {
             if (error) {
                 this.telemetry
                     .add("error.description", "ErrorOnChildProcess on addExecutePermission", /*isPii*/ false)
@@ -223,7 +223,7 @@ class AndroidSdkInstaller extends InstallerBase {
         var deferred: Q.Deferred<any> = Q.defer<any>();
 
         var adbProcess: childProcess.ChildProcess = childProcess.spawn("adb", ["kill-server"]);
-        adbProcess.on("error", function (error: Error): void {
+        adbProcess.on("error", (error: Error) => {
             this.telemetry
                 .add("error.description", "ErrorOnKillingAdb in killAdb", /*isPii*/ false)
                 .addError(error);
@@ -264,13 +264,13 @@ class AndroidSdkInstaller extends InstallerBase {
         cp.stderr.on("data", function (data: Buffer): void {
             errorOutput += data.toString();
         });
-        cp.on("error", function (err: Error): void {
+        cp.on("error", (err: Error) => {
             this.telemetry
                 .add("error.description", "ErrorOnChildProcess on postInstallDefault", /*isPii*/ false)
                 .addError(err);
             deferred.reject(err);
         });
-        cp.on("exit", function (code: number): void {
+        cp.on("exit", (code: number) => {
             if (errorOutput) {
                 this.telemetry
                     .add("error.description", "ErrorOnExitOfChildProcess on postInstallDefault", /*isPii*/ false)

--- a/src/taco-dependency-installer/installers/javaJdkInstaller.ts
+++ b/src/taco-dependency-installer/installers/javaJdkInstaller.ts
@@ -54,7 +54,7 @@ class JavaJdkInstaller extends InstallerBase {
         // Run installer
         var commandLine: string = this.installerDownloadPath + " /quiet /norestart /lvx %temp%/javajdk.log /INSTALLDIR=" + utils.quotesAroundIfNecessary(this.installDestination);
 
-        childProcess.exec(commandLine, function (err: Error): void {
+        childProcess.exec(commandLine, (err: Error) => {
             if (err) {
                 this.telemetry.addError(err);
                 var code: number = (<any>err).code;
@@ -110,7 +110,7 @@ class JavaJdkInstaller extends InstallerBase {
         var deferred: Q.Deferred<any> = Q.defer<any>();
         var command: string = "hdiutil attach " + this.installerDownloadPath;
 
-        childProcess.exec(command, function (error: Error, stdout: Buffer, stderr: Buffer): void {
+        childProcess.exec(command, (error: Error, stdout: Buffer, stderr: Buffer) => {
             // Save the mounted volume's name
             var stringOutput: string = stdout.toString();
             var capturedResult: string[] = /\/Volumes\/(.+)/.exec(stringOutput);
@@ -136,7 +136,7 @@ class JavaJdkInstaller extends InstallerBase {
         var pkgPath: string = path.join("/", "Volumes", this.darwinMountpointName, this.darwinMountpointName + ".pkg");
         var commandLine: string = "installer -pkg \"" + pkgPath + "\" -target \"/\"";
 
-        childProcess.exec(commandLine, function (err: Error): void {
+        childProcess.exec(commandLine, (err: Error) => {
             if (err) {
                 this.telemetry.addError(err);
                 var code: number = (<any>err).code;
@@ -164,7 +164,7 @@ class JavaJdkInstaller extends InstallerBase {
         var mountPath: string = path.join("/", "Volumes", this.darwinMountpointName);
         var command: string = "hdiutil detach \"" + mountPath + "\"";
 
-        childProcess.exec(command, function (error: Error, stdout: Buffer, stderr: Buffer): void {
+        childProcess.exec(command, (error: Error, stdout: Buffer, stderr: Buffer) => {
             if (error) {
                 this.telemetry
                     .add("error.description", "ErrorOnChildProcess on detachDmg", /*isPii*/ false)


### PR DESCRIPTION
We were using normal lambda functions instead of typescript functions, so the this pointer was undefined.
Changing to typescript lambda functions should fix the crash
