### PR TITLE
Build parallel

### DIFF
--- a/src/taco-cli/cli/build.ts
+++ b/src/taco-cli/cli/build.ts
@@ -181,8 +181,8 @@ class Build extends commands.TacoCommandBase {
         return Q.all([Settings.determinePlatform(commandData), Settings.loadSettingsOrReturnEmpty()])
            .spread((platforms: Settings.IPlatformWithLocation[], settings: Settings.ISettings) => {
             buildTelemetryHelper.storePlatforms(telemetryProperties, "actuallyBuilt", platforms, settings);
-            return platforms.reduce<Q.Promise<any>>((soFar: Q.Promise<any>, platform: Settings.IPlatformWithLocation) => {
-                return soFar.then(() => {
+            return Q.all(platforms.map((platform: Settings.IPlatformWithLocation) => {
+                return Q({}).then(() => {
                     if (commandData.options["clean"]) {
                         return Build.cleanPlatform(platform, commandData);
                     } else {
@@ -200,7 +200,7 @@ class Build extends commands.TacoCommandBase {
                             return Q.reject(errorHelper.get(TacoErrorCodes.CommandBuildInvalidPlatformLocation, platform.platform));
                     }
                 });
-            }, Q({}));
+            }));
         }).then(() => Build.generateTelemetryProperties(telemetryProperties, commandData));
     }
 }

--- a/src/taco-cli/cli/emulate.ts
+++ b/src/taco-cli/cli/emulate.ts
@@ -163,18 +163,16 @@ class Emulate extends commands.TacoCommandBase {
         return Q.all([Settings.determinePlatform(commandData), Settings.loadSettingsOrReturnEmpty()])
             .spread((platforms: Settings.IPlatformWithLocation[], settings: Settings.ISettings) => {
                 buildTelemetryHelper.storePlatforms(telemetryProperties, "actuallyBuilt", platforms, settings);
-                return platforms.reduce<Q.Promise<any>>(function (soFar: Q.Promise<any>, platform: Settings.IPlatformWithLocation): Q.Promise<any> {
-                    return soFar.then(function (): Q.Promise<any> {
-                        switch (platform.location) {
-                            case Settings.BuildLocationType.Local:
-                                // Just run local, and failures are failures
-                                return CordovaWrapper.emulate(commandData, platform.platform);
-                            case Settings.BuildLocationType.Remote:
-                                // Just run remote, and failures are failures
-                                return Emulate.runRemotePlatform(platform.platform, commandData, telemetryProperties);
-                        }
-                    });
-                }, Q({}));
+                return Q.all(platforms.map((platform: Settings.IPlatformWithLocation): Q.Promise<any> => {
+                    switch (platform.location) {
+                        case Settings.BuildLocationType.Local:
+                            // Just run local, and failures are failures
+                            return CordovaWrapper.emulate(commandData, platform.platform);
+                        case Settings.BuildLocationType.Remote:
+                            // Just run remote, and failures are failures
+                            return Emulate.runRemotePlatform(platform.platform, commandData, telemetryProperties);
+                    }
+                }));
             }).then(() => Emulate.generateTelemetryProperties(telemetryProperties, commandData));
     }
 }

--- a/src/taco-cli/cli/run.ts
+++ b/src/taco-cli/cli/run.ts
@@ -213,18 +213,16 @@ class Run extends commands.TacoCommandBase {
         return Q.all([Settings.determinePlatform(commandData), Settings.loadSettingsOrReturnEmpty()])
             .spread((platforms: Settings.IPlatformWithLocation[], settings: Settings.ISettings) => {
             buildTelemetryHelper.storePlatforms(telemetryProperties, "actuallyBuilt", platforms, settings);
-            return platforms.reduce<Q.Promise<any>>(function (soFar: Q.Promise<any>, platform: Settings.IPlatformWithLocation): Q.Promise<any> {
-                return soFar.then(function (): Q.Promise<any> {
-                    switch (platform.location) {
-                        case Settings.BuildLocationType.Local:
-                            // Just run local, and failures are failures
-                            return CordovaWrapper.run(commandData, platform.platform);
-                        case Settings.BuildLocationType.Remote:
-                            // Just run remote, and failures are failures
-                            return Run.runRemotePlatform(platform.platform, commandData, telemetryProperties);
-                    }
-                });
-            }, Q({}));
+            return Q.all(platforms.map((platform: Settings.IPlatformWithLocation): Q.Promise<any> => {
+                switch (platform.location) {
+                    case Settings.BuildLocationType.Local:
+                        // Just run local, and failures are failures
+                        return CordovaWrapper.run(commandData, platform.platform);
+                    case Settings.BuildLocationType.Remote:
+                        // Just run remote, and failures are failures
+                        return Run.runRemotePlatform(platform.platform, commandData, telemetryProperties);
+                }
+            }));
         }).then(() => Run.generateTelemetryProperties(telemetryProperties, commandData));
     }
 }

--- a/src/taco-cli/test/build.ts
+++ b/src/taco-cli/test/build.ts
@@ -385,6 +385,6 @@ describe("taco build", function (): void {
     });
 
     describe("telemetry", () => {
-        buildAndRunTelemetry.createBuildAndRunTelemetryTests.call(this, buildRun, () => testHttpServer, Command.Build);
+        buildAndRunTelemetry.createBuildAndRunTelemetryTests.call(this, buildRun, Command.Build);
     });
 });

--- a/src/taco-cli/test/buildAndRunTelemetry.ts
+++ b/src/taco-cli/test/buildAndRunTelemetry.ts
@@ -83,15 +83,16 @@ module BuildAndRunTelemetryTests {
         Emulate
     }
 
-    export function createBuildAndRunTelemetryTests(runCommand: { (args: string[]): Q.Promise<TacoUtility.ICommandTelemetryProperties> },
-        getTestHttpServer: { (): http.Server }, command: Command): void {
+    export function createBuildAndRunTelemetryTests(runCommand: { (args: string[]): Q.Promise<TacoUtility.ICommandTelemetryProperties> }, command: Command): void {
         var tacoHome = path.join(os.tmpdir(), "taco-cli", commandSwitch("build", "run", "emulate"));
         var projectPath = path.join(tacoHome, "example");
-        var testHttpServer: http.Server;
+        var testIosHttpServer: http.Server;
+        var testAndroidHttpServer: http.Server;
+        var iosPort = 3001;
+        var androidPort = 3002;
 
         var cordova: Cordova.ICordova = new mockCordova.MockCordova510();
         var vcordova: string = "4.0.0";
-        var remoteServerConfiguration = { host: "localhost", port: 3000, secure: false, mountPoint: "cordova" };
         var buildNumber = 12341;
         var isNotEmulate = command !== Command.Emulate;
 
@@ -102,7 +103,15 @@ module BuildAndRunTelemetryTests {
         };
 
         before(() => {
-            testHttpServer = getTestHttpServer();
+            testIosHttpServer = http.createServer();
+            testIosHttpServer.listen(iosPort);
+            testAndroidHttpServer = http.createServer();
+            testAndroidHttpServer.listen(androidPort);
+        });
+
+        after(() => {
+            testIosHttpServer.close();
+            testAndroidHttpServer.close();
         });
 
         // We mock cordova build
@@ -120,7 +129,7 @@ module BuildAndRunTelemetryTests {
             return Q({});
         };
 
-        function generateCompleteBuildSequence(platform: string, isIncrementalTest: boolean): any {
+        function generateCompleteBuildSequence(platform: string, port: number, isIncrementalTest: boolean): any {
             var configuration = "debug";
         
             // Mock out the server on the other side
@@ -140,7 +149,7 @@ module BuildAndRunTelemetryTests {
                 expectedUrl: "/cordova/build/tasks?" + querystring.stringify(queryOptions),
                 head: {
                     "Content-Type": "application/json",
-                    "Content-Location": "http://localhost:3000/cordova/build/tasks/" + buildNumber
+                    "Content-Location": "http://localhost:" + port + "/cordova/build/tasks/" + buildNumber
                 },
                 statusCode: 202,
                 response: JSON.stringify(new BuildInfo({ status: BuildInfo.UPLOADING, buildNumber: buildNumber, buildLang: "en" })),
@@ -159,7 +168,7 @@ module BuildAndRunTelemetryTests {
                     expectedUrl: "/cordova/build/tasks?" + querystring.stringify(queryOptions),
                     head: {
                         "Content-Type": "application/json",
-                        "Content-Location": "http://localhost:3000/cordova/build/tasks/" + buildNumber
+                        "Content-Location": "http://localhost:" + port + "/cordova/build/tasks/" + buildNumber
                     },
                     statusCode: 202,
                     response: JSON.stringify(new BuildInfo({ status: BuildInfo.UPLOADING, buildNumber: buildNumber, buildLang: "en" })),
@@ -230,18 +239,20 @@ module BuildAndRunTelemetryTests {
         }
 
         function configureRemoteServer(done: MochaDone, isIncrementalTest: boolean): Q.Promise<any> {
-            var sequence = generateCompleteBuildSequence("ios", isIncrementalTest);
+            var iosSequence = generateCompleteBuildSequence("ios", iosPort, isIncrementalTest);
+            var androidSequence = generateCompleteBuildSequence("android", androidPort, isIncrementalTest);
+
+            var iosServerFunction = ServerMock.generateServerFunction(done, iosSequence);
+            var androidServerFunction = ServerMock.generateServerFunction(done, androidSequence);
+            testIosHttpServer.on("request", iosServerFunction);
+
             if (!isIncrementalTest) {
-                var androidSequence = generateCompleteBuildSequence("android", isIncrementalTest);
-                sequence = androidSequence.concat(sequence);
+                testAndroidHttpServer.on("request", androidServerFunction);
             }
 
-            var serverFunction = ServerMock.generateServerFunction(done, sequence);
-            testHttpServer.on("request", serverFunction);
-
-            var platforms: { [platform: string]: Settings.IRemoteConnectionInfo } = { ios: remoteServerConfiguration };
+            var platforms: { [platform: string]: Settings.IRemoteConnectionInfo } = { ios: { host: "localhost", port: iosPort, secure: false, mountPoint: "cordova" } };
             if (!isIncrementalTest) {
-                platforms["android"] = remoteServerConfiguration;
+                platforms["android"] = { host: "localhost", port: androidPort, secure: false, mountPoint: "cordova" };
             }
 
             return Settings.saveSettings({ remotePlatforms: platforms });
@@ -320,10 +331,9 @@ module BuildAndRunTelemetryTests {
                 expected["platforms.actuallyBuilt.local1"] = { isPii: false, value: "android" };
             }
 
-            runCommand(args).done(telemetryProperties => {
-                telemetryShouldEqual(telemetryProperties, expected);
-                done();
-            });
+            runCommand(args)
+                .then(telemetryProperties => telemetryShouldEqual(telemetryProperties, expected))
+                .done(() => done(), done);
         });
 
         function mockProjectWithIncrementalBuild(): void {
@@ -356,7 +366,10 @@ module BuildAndRunTelemetryTests {
             mockProjectWithIncrementalBuild();
             configureRemoteServer(done, /* Incremental test*/ true)
                 .then(() => runCommand(args))
-                .finally(() => testHttpServer.removeAllListeners("request"))
+                .finally(() => {
+                    testIosHttpServer.removeAllListeners("request");
+                    testAndroidHttpServer.removeAllListeners("request")
+                })
                 .then(telemetryProperties => {
                     telemetryShouldEqual(telemetryProperties, expected, 28382);
                 }).done(() => done(), done);
@@ -384,11 +397,12 @@ module BuildAndRunTelemetryTests {
 
             configureRemoteServer(done, /* Not incremental test*/ false)
                 .then(() => runCommand(args))
-                .finally(() => testHttpServer.removeAllListeners("request"))
-                .done(telemetryProperties => {
-                    telemetryShouldEqual(telemetryProperties, expected, 28427, 28379);
-                    done();
-                });
+                .finally(() => {
+                    testIosHttpServer.removeAllListeners("request");
+                    testAndroidHttpServer.removeAllListeners("request")
+                })
+                .then(telemetryProperties => telemetryShouldEqual(telemetryProperties, expected, 28427, 28379))
+                .done(() => done(), done);
         });
 
         it("4. no command line platforms, implicit windows wp8 device", (done: MochaDone) => {
@@ -408,10 +422,9 @@ module BuildAndRunTelemetryTests {
                 expected["options.device"] = { isPii: false, value: "true" };
             }
 
-            runCommand(args).done(telemetryProperties => {
-                telemetryShouldEqual(telemetryProperties, expected);
-                done();
-            });
+            runCommand(args)
+                .then(telemetryProperties => telemetryShouldEqual(telemetryProperties, expected))
+                .then(() => done(), done);
         });
 
         it("5. --uknown_option unknown_platform", (done: MochaDone) => {
@@ -441,10 +454,9 @@ module BuildAndRunTelemetryTests {
                     subCommand: { isPii: false, value: commandSwitch("build", "fallback", "emulate") }
                 };
 
-                runCommand(args).done(telemetryProperties => {
-                    telemetryShouldEqual(telemetryProperties, expected);
-                    done();
-                });
+                runCommand(args)
+                    .then(telemetryProperties => telemetryShouldEqual(telemetryProperties, expected))
+                    .then(() => done(), done)
             });
         }
     }

--- a/src/taco-cli/test/buildAndRunTelemetry.ts
+++ b/src/taco-cli/test/buildAndRunTelemetry.ts
@@ -389,10 +389,10 @@ module BuildAndRunTelemetryTests {
                 "remoteBuild.android.wasIncremental": { isPii: false, value: "false" },
                 "remotebuild.android.gzipedProjectSizeInBytes": { isPii: false, value: "28379" },
                 "remotebuild.android.projectSizeInBytes": { isPii: false, value: "48128" },
-                "remoteBuild.ios.filesChangedCount": { isPii: false, value: 9 },
+                "remoteBuild.ios.filesChangedCount": { isPii: false, value: 8 },
                 "remoteBuild.ios.wasIncremental": { isPii: false, value: "false" },
-                "remotebuild.ios.gzipedProjectSizeInBytes": { isPii: false, value: "28427" },
-                "remotebuild.ios.projectSizeInBytes": { isPii: false, value: "49152" }
+                "remotebuild.ios.gzipedProjectSizeInBytes": { isPii: false, value: "28379" },
+                "remotebuild.ios.projectSizeInBytes": { isPii: false, value: "48128" }
             };
 
             configureRemoteServer(done, /* Not incremental test*/ false)
@@ -401,7 +401,7 @@ module BuildAndRunTelemetryTests {
                     testIosHttpServer.removeAllListeners("request");
                     testAndroidHttpServer.removeAllListeners("request")
                 })
-                .then(telemetryProperties => telemetryShouldEqual(telemetryProperties, expected, 28427, 28379))
+                .then(telemetryProperties => telemetryShouldEqual(telemetryProperties, expected, 28379, 28379))
                 .done(() => done(), done);
         });
 

--- a/src/taco-cli/test/emulate.ts
+++ b/src/taco-cli/test/emulate.ts
@@ -112,6 +112,6 @@ describe("taco emulate", function (): void {
     };
 
     describe("telemetry", () => {
-        buildAndRunTelemetry.createBuildAndRunTelemetryTests.call(this, emulateRun, () => testHttpServer, Command.Emulate);
+        buildAndRunTelemetry.createBuildAndRunTelemetryTests.call(this, emulateRun, Command.Emulate);
     });
 });

--- a/src/taco-cli/test/run.ts
+++ b/src/taco-cli/test/run.ts
@@ -245,6 +245,6 @@ describe("taco run", function (): void {
     });
 
     describe("telemetry", () => {
-        buildAndRunTelemetry.createBuildAndRunTelemetryTests.call(this, runRun, () => testHttpServer, Command.Run);
+        buildAndRunTelemetry.createBuildAndRunTelemetryTests.call(this, runRun, Command.Run);
     });
 });


### PR DESCRIPTION
With this change we try to build/run/emulate multiple platforms in parallel rather than sequentially.
This requires that we update some test expectations. Since we can build multiple remotes at once, we separate the remote servers to different ports to make the test expectations easier to check, and we update the test expectations so it no longer assumes that one build completes before the other starts, and thus some outputs of the first build could appear in the other.