### PR TITLE
Updating streamToPromise to handle 'end' events

### DIFF
--- a/tools/GulpUtils.ts
+++ b/tools/GulpUtils.ts
@@ -199,6 +199,9 @@ class GulpUtils {
         stream.on("finish", function (): void {
             deferred.resolve({});
         });
+        stream.on("end", function (): void {
+            deferred.resolve({});
+        });
         stream.on("error", function (e: Error): void {
             deferred.reject(e);
         });


### PR DESCRIPTION
The gulp-tslint stream only emits an 'end' event, not a 'finished' event, so the streamToPromise function wasn't noticing the end and things ended in a deadlock.