### PR TITLE
Now we show a note after reseting the certificates, informing the user that he needs to reset the running servers for the change to take effect

### DIFF
--- a/src/remotebuild/lib/darwin/darwinCerts.ts
+++ b/src/remotebuild/lib/darwin/darwinCerts.ts
@@ -68,7 +68,11 @@ class Certs {
             then(function (shouldProceed: boolean): Q.Promise<any> {
                 if (shouldProceed) {
                     rimraf.sync(certsDir);
-                    return Certs.initializeServerCerts(conf);
+                    return Certs.initializeServerCerts(conf)
+                        .then(result => {
+                            logger.log(resources.getString("OSXNoteAfterResetServerCert"));
+                            return result;
+                        });
                 }
 
                 return Q({});

--- a/src/remotebuild/lib/darwin/darwinCerts.ts
+++ b/src/remotebuild/lib/darwin/darwinCerts.ts
@@ -69,7 +69,7 @@ class Certs {
                 if (shouldProceed) {
                     rimraf.sync(certsDir);
                     return Certs.initializeServerCerts(conf)
-                        .then(result => {
+                        .then((result: HostSpecifics.ICertStore): HostSpecifics.ICertStore => {
                             logger.log(resources.getString("OSXNoteAfterResetServerCert"));
                             return result;
                         });

--- a/src/remotebuild/resources/en/resources.json
+++ b/src/remotebuild/resources/en/resources.json
@@ -103,7 +103,7 @@
     "_CertificatesNotConfigured.comment": "Error returned when certificates are accessed before initialization.",
     "OSXResetServerCertQuery": "Warning: This command deletes all current client certificates. You will need to generate and configure a new security PIN. Do you want to continue? [Y]es or [N]o",
     "_OSXResetServerCertQuery.comment": "Message printed when user invokes resetServerCert command asking if they are sure",
-    "OSXNoteAfterResetServerCert": "Note: You need to restart any running remote build servers for this change to take effect, and have the certificates be actually reseted",
+    "OSXNoteAfterResetServerCert": "Note: You need to restart any running remotebuild servers before the new certificates will be used.",
     "_OSXNoteAfterResetServerCert.comment": "Message printed after the user invokes resetServerCert command to inform them that they need to reset the certificates for this change to be picked up",
     "OSXResetServerCertResponseYes": [ "y", "yes" ],
     "_OSXResetServerCertResponseYes.comment": "List of responses that are considered affirmative. User input will be converted to lower case before consulting this list",

--- a/src/remotebuild/resources/en/resources.json
+++ b/src/remotebuild/resources/en/resources.json
@@ -103,6 +103,8 @@
     "_CertificatesNotConfigured.comment": "Error returned when certificates are accessed before initialization.",
     "OSXResetServerCertQuery": "Warning: This command deletes all current client certificates. You will need to generate and configure a new security PIN. Do you want to continue? [Y]es or [N]o",
     "_OSXResetServerCertQuery.comment": "Message printed when user invokes resetServerCert command asking if they are sure",
+    "OSXNoteAfterResetServerCert": "Note: You need to restart any running remote build servers for this change to take effect, and have the certificates be actually reseted",
+    "_OSXNoteAfterResetServerCert.comment": "Message printed after the user invokes resetServerCert command to inform them that they need to reset the certificates for this change to be picked up",
     "OSXResetServerCertResponseYes": [ "y", "yes" ],
     "_OSXResetServerCertResponseYes.comment": "List of responses that are considered affirmative. User input will be converted to lower case before consulting this list",
     "OSXResetServerCertResponseNo": [ "n", "no" ],


### PR DESCRIPTION
Now the UX looks like:
> ./remotebuild certificates reset
Warning: This command deletes all current client certificates. You will need to generate and configure a new security PIN. Do you want to continue? [Y]es or [N]o
y
Note: You need to restart any running remote build servers for this change to take effect, and have the certificates be actually reseted
>
