### PR TITLE
Now we hide the npm warnings and normal output while installing packages, but we still show errors

### DIFF
--- a/src/taco-cli/cli/utils/cordovaWrapper.ts
+++ b/src/taco-cli/cli/utils/cordovaWrapper.ts
@@ -151,7 +151,7 @@ class CordovaWrapper {
         CordovaHelper.prepareCordovaConfig(cordovaParameters);
         return CordovaHelper.wrapCordovaInvocation<any>(cordovaCliVersion, (cordova: Cordova.ICordova) => {
             return cordova.raw.create(cordovaParameters.projectPath, cordovaParameters.appId, cordovaParameters.appName, cordovaParameters.cordovaConfig);
-        }, tacoUtility.InstallLogLevel.taco);
+        }, tacoUtility.InstallLogLevel.error);
     }
 
     public static getGlobalCordovaVersion(): Q.Promise<string> {

--- a/src/taco-cli/cli/utils/kitHelper.ts
+++ b/src/taco-cli/cli/utils/kitHelper.ts
@@ -102,7 +102,8 @@ class KitHelper {
 
     private static acquireKitPackage(): Q.Promise<ITacoKits> {
         if (!KitHelper.kitPackagePromise) {
-            KitHelper.kitPackagePromise = TacoPackageLoader.lazyTacoRequire<ITacoKits>(KitHelper.TACO_KITS_NPM_PACKAGE_NAME, KitHelper.dynamicDependenciesLocation, tacoUtility.InstallLogLevel.taco);
+            KitHelper.kitPackagePromise = TacoPackageLoader.lazyTacoRequire<ITacoKits>(KitHelper.TACO_KITS_NPM_PACKAGE_NAME,
+                KitHelper.dynamicDependenciesLocation, tacoUtility.InstallLogLevel.error);
         }
 
         return KitHelper.kitPackagePromise;

--- a/src/taco-utils/installLogLevel.ts
+++ b/src/taco-utils/installLogLevel.ts
@@ -12,9 +12,9 @@ module TacoUtility {
     export enum InstallLogLevel {
         undefined = 0, // undefined is falsy, others are truthy
         silent = 1,
+        taco,
         error,
         warn,
-        taco,
         info,
         verbose,
         silly,

--- a/src/taco-utils/tacoPackageLoader.ts
+++ b/src/taco-utils/tacoPackageLoader.ts
@@ -311,7 +311,7 @@ module TacoUtility {
             var npmExecutable = process.platform === "win32" ? "npm.cmd" : "npm";
 
             var stdio: any = logLevel === InstallLogLevel.error // On the default error message level, we don't want to show npm output messages
-                ? [/*stdin*/ "ignore", /*stdin*/ "ignore", /*stderr*/ process.stderr] // So we inherit stderr but we ignore stdin and stdout
+                ? [/*stdin*/ "ignore", /*stdout*/ "ignore", /*stderr*/ process.stderr] // So we inherit stderr but we ignore stdin and stdout
                 : "inherit"; // For silent everything is ignored, so it doesn't matter, for everything else we just let npm inherit all our streams
 
             var npmProcess = child_process.spawn(npmExecutable, args, { cwd: cwd, stdio: stdio });

--- a/src/taco-utils/tacoPackageLoader.ts
+++ b/src/taco-utils/tacoPackageLoader.ts
@@ -309,7 +309,12 @@ module TacoUtility {
             }
 
             var npmExecutable = process.platform === "win32" ? "npm.cmd" : "npm";
-            var npmProcess = child_process.spawn(npmExecutable, args, { cwd: cwd, stdio: "inherit" });
+
+            var stdio: any = logLevel === InstallLogLevel.error // On the default error message level, we don't want to show npm output messages
+                ? [/*stdin*/ "ignore", /*stdin*/ "ignore", /*stderr*/ process.stderr] // So we inherit stderr but we ignore stdin and stdout
+                : "inherit"; // For silent everything is ignored, so it doesn't matter, for everything else we just let npm inherit all our streams
+
+            var npmProcess = child_process.spawn(npmExecutable, args, { cwd: cwd, stdio: stdio });
             npmProcess.on("error", function (error: Error): void {
                 deferred.reject(error);
             });


### PR DESCRIPTION
Now we won't see all the npm warnings nor the output of all the package dependencies.