### PR TITLE
Bumping more test timeouts

### DIFF
--- a/src/taco-cli/test/kit.ts
+++ b/src/taco-cli/test/kit.ts
@@ -183,10 +183,9 @@ describe("Kit", function (): void {
             "cordova-cli": "5.1.1"
         };
 
-        this.timeout(30000);
+        this.timeout(60000);
 
         before(function (done: MochaDone): void {
-            this.timeout(60000);
             createKitProject("5.1.1-Kit")
             .done(function (): void {
                 process.chdir(kitProjectpath);
@@ -219,10 +218,9 @@ describe("Kit", function (): void {
             kit: "5.1.1-Kit", "cordova-cli": "5.1.1"
         };
 
-        this.timeout(30000);
+        this.timeout(60000);
 
         before(function (done: MochaDone): void {
-            this.timeout(60000);
             createCliProject("5.1.1")
             .done(function (): void {
                 process.chdir(cliProjectpath);
@@ -231,7 +229,6 @@ describe("Kit", function (): void {
         });
 
         after(function (done: MochaDone): void {
-            this.timeout(30000);
             process.chdir(tacoHome);
             rimraf(cliProjectpath, function (err: Error): void { done(); }); // ignore errors
         });

--- a/src/taco-cli/test/run.ts
+++ b/src/taco-cli/test/run.ts
@@ -45,7 +45,7 @@ import utils = TacoUtility.UtilHelper;
 var create: createMod = new createMod();
 
 describe("taco run", function (): void {
-    this.timeout(20000); // The remote tests sometimes take some time to run
+    this.timeout(60000); // The remote tests sometimes take some time to run
     var testHttpServer: http.Server;
     var tacoHome: string = path.join(os.tmpdir(), "taco-cli", "run");
     var originalCwd: string;
@@ -89,7 +89,6 @@ describe("taco run", function (): void {
     });
 
     after(function (done: MochaDone): void {
-        this.timeout(30000);
         process.chdir(originalCwd);
         kitHelper.kitPackagePromise = null;
         testHttpServer.close();
@@ -97,7 +96,6 @@ describe("taco run", function (): void {
     });
 
     beforeEach(function (mocha: MochaDone): void {
-        this.timeout(50000);
         Q.fcall(createCleanProject).done(function (): void {
             mocha();
         }, function (err: any): void {


### PR DESCRIPTION
Looks like some of the previous increased test timeouts didn't apply and I was just lucky that they didn't go over. I've moved their specification out of the before() handler and into the describe() handler.

Also increasing some other timeouts that failed, although that may have been a knock-on effect.