### PR TITLE
Changing version of taco-cli used in test

### DIFF
--- a/src/taco-cli/test/create.ts
+++ b/src/taco-cli/test/create.ts
@@ -695,11 +695,11 @@ describe("taco create", function (): void {
 
             var expected: TacoUtility.ICommandTelemetryProperties = {
                         cliVersion: { isPii: false, value: cliVersion },
-                        cordova: { isPii: false, value: "5.2.0" },
-                        "options.cordova": { isPii: false, value: "5.2.0" }
+                        cordova: { isPii: false, value: "4.3.0" },
+                        "options.cordova": { isPii: false, value: "4.3.0" }
             };
 
-            createProjectAndVerifyTelemetryProps([projectPath, "--cordova", "5.2.0"], expected, done);
+            createProjectAndVerifyTelemetryProps([projectPath, "--cordova", "4.3.0"], expected, done);
         });
     });
 });


### PR DESCRIPTION
Changing the version from 5.2.0 to 4.3.0. This means that it matches the version used in other tests, and can be used from the cache rather than being redownloaded for this one test. Should improve test reliability.