### PR TITLE
Adding a static class to properly construct command objects for tests.

### DIFF
--- a/src/taco-cli/test/build.ts
+++ b/src/taco-cli/test/build.ts
@@ -33,7 +33,6 @@ import util = require ("util");
 
 import buildAndRunTelemetry = require ("./buildAndRunTelemetry");
 import buildMod = require ("../cli/build");
-import createMod = require ("../cli/create");
 import IHttpServerFunction = require ("./utils/httpServerFunction");
 import kitHelper = require ("../cli/utils/kitHelper");
 import mockCordova = require ("./utils/mockCordova");
@@ -50,8 +49,11 @@ import BuildInfo = TacoUtility.BuildInfo;
 import Command = buildAndRunTelemetry.Command;
 import utils = TacoUtility.UtilHelper;
 
-var build: buildMod = new buildMod();
-var create: createMod = new createMod();
+import commandHelper = require("./utils/commandHelper");
+import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+
+var build: TacoCommandBase = commandHelper.getCommand("build");
+var create: TacoCommandBase = commandHelper.getCommand("create");
 
 describe("taco build", function (): void {
     var testHttpServer: http.Server;
@@ -119,7 +121,7 @@ describe("taco build", function (): void {
     });
 
     var buildRun: (args: string[]) => Q.Promise<TacoUtility.ICommandTelemetryProperties> = function (args: string[]): Q.Promise<TacoUtility.ICommandTelemetryProperties> {
-        var command: buildMod = new buildMod();
+        var command: TacoCommandBase = commandHelper.getCommand("build");
         return command.run({
             options: {},
             original: args,

--- a/src/taco-cli/test/build.ts
+++ b/src/taco-cli/test/build.ts
@@ -49,11 +49,11 @@ import BuildInfo = TacoUtility.BuildInfo;
 import Command = buildAndRunTelemetry.Command;
 import utils = TacoUtility.UtilHelper;
 
-import commandHelper = require("./utils/commandHelper");
-import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+import CommandHelper = require("./utils/commandHelper");
+import ICommand = TacoUtility.Commands.ICommand;
 
-var build: TacoCommandBase = commandHelper.getCommand("build");
-var create: TacoCommandBase = commandHelper.getCommand("create");
+var build: ICommand = CommandHelper.getCommand("build");
+var create: ICommand = CommandHelper.getCommand("create");
 
 describe("taco build", function (): void {
     var testHttpServer: http.Server;
@@ -121,7 +121,7 @@ describe("taco build", function (): void {
     });
 
     var buildRun: (args: string[]) => Q.Promise<TacoUtility.ICommandTelemetryProperties> = function (args: string[]): Q.Promise<TacoUtility.ICommandTelemetryProperties> {
-        var command: TacoCommandBase = commandHelper.getCommand("build");
+        var command: ICommand = CommandHelper.getCommand("build");
         return command.run({
             options: {},
             original: args,

--- a/src/taco-cli/test/buildAndRunTelemetry.ts
+++ b/src/taco-cli/test/buildAndRunTelemetry.ts
@@ -43,11 +43,11 @@ import TacoUtility = require ("taco-utils");
 import BuildInfo = TacoUtility.BuildInfo;
 import utils = TacoUtility.UtilHelper;
 
-import commandHelper = require ("./utils/commandHelper");
-import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+import CommandHelper = require ("./utils/commandHelper");
+import ICommand = TacoUtility.Commands.ICommand;
 
-var build: TacoCommandBase = commandHelper.getCommand("build");
-var create: TacoCommandBase = commandHelper.getCommand("create");
+var build: ICommand = CommandHelper.getCommand("build");
+var create: ICommand = CommandHelper.getCommand("create");
 
 interface IExpectedRequest {
     expectedUrl: string;

--- a/src/taco-cli/test/buildAndRunTelemetry.ts
+++ b/src/taco-cli/test/buildAndRunTelemetry.ts
@@ -28,8 +28,6 @@ import querystring = require ("querystring");
 import rimraf = require ("rimraf");
 import util = require ("util");
 
-import buildMod = require ("../cli/build");
-import createMod = require ("../cli/create");
 import IHttpServerFunction = require ("./utils/httpServerFunction");
 import kitHelper = require ("../cli/utils/kitHelper");
 import mockCordova = require ("./utils/mockCordova");
@@ -45,8 +43,11 @@ import TacoUtility = require ("taco-utils");
 import BuildInfo = TacoUtility.BuildInfo;
 import utils = TacoUtility.UtilHelper;
 
-var build: buildMod = new buildMod();
-var create: createMod = new createMod();
+import commandHelper = require ("./utils/commandHelper");
+import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+
+var build: TacoCommandBase = commandHelper.getCommand("build");
+var create: TacoCommandBase = commandHelper.getCommand("create");
 
 interface IExpectedRequest {
     expectedUrl: string;

--- a/src/taco-cli/test/create.ts
+++ b/src/taco-cli/test/create.ts
@@ -35,7 +35,6 @@ import rimraf = require ("rimraf");
 import util = require ("util");
 import wrench = require ("wrench");
 
-import Create = require ("../cli/create");
 import kitHelper = require ("../cli/utils/kitHelper");
 import resources = require ("../resources/resourceManager");
 import TacoErrorCodes = require ("../cli/tacoErrorCodes");
@@ -47,6 +46,9 @@ import ms = require ("./utils/memoryStream");
 import TacoKitsErrorCodes = tacoKits.TacoErrorCode;
 import TacoUtilsErrorCodes = tacoUtils.TacoErrorCode;
 import utils = tacoUtils.UtilHelper;
+
+import commandHelper = require ("./utils/commandHelper");
+import TacoCommandBase = tacoUtils.Commands.TacoCommandBase;
 
 interface IScenarioList {
     [scenario: number]: string;
@@ -170,7 +172,7 @@ describe("taco create", function (): void {
     }
 
     function runScenarioWithExpectedFileCount(scenario: number, expectedFileCount: number, tacoJsonFileContents?: IKeyValuePair<string>): Q.Promise<any> {
-        var create: Create = new Create();
+        var create: TacoCommandBase = commandHelper.getCommand("create");
 
         return create.run(makeICommandData(scenario, successScenarios))
             .then(function (): void {
@@ -195,7 +197,7 @@ describe("taco create", function (): void {
     }
 
     function runFailureScenario<T>(scenario: number, expectedErrorCode?: T): Q.Promise<any> {
-        var create: Create = new Create();
+        var create: TacoCommandBase = commandHelper.getCommand("create");
 
         return create.run(makeICommandData(scenario, failureScenarios))
             .then(function (): Q.Promise<any> {
@@ -469,7 +471,7 @@ describe("taco create", function (): void {
                 original: createCommandLineArguments,
                 remain: createCommandLineArguments.slice()
             };
-            var create: Create = new Create();
+            var create: TacoCommandBase = commandHelper.getCommand("create");
             create.run(commandData).done(() => {
                 var expected : string = expectedMessages.join("\n");
 
@@ -644,7 +646,7 @@ describe("taco create", function (): void {
         var cliVersion: string = require("../package.json").version;
 
         function createProjectAndVerifyTelemetryProps(args: string[], expectedProperties: TacoUtility.ICommandTelemetryProperties, done: MochaDone): void {
-            var create: Create = new Create();
+            var create: TacoCommandBase = commandHelper.getCommand("create");
             var commandData: tacoUtils.Commands.ICommandData = {
                 options: {},
                 original: args,

--- a/src/taco-cli/test/create.ts
+++ b/src/taco-cli/test/create.ts
@@ -47,8 +47,8 @@ import TacoKitsErrorCodes = tacoKits.TacoErrorCode;
 import TacoUtilsErrorCodes = tacoUtils.TacoErrorCode;
 import utils = tacoUtils.UtilHelper;
 
-import commandHelper = require ("./utils/commandHelper");
-import TacoCommandBase = tacoUtils.Commands.TacoCommandBase;
+import CommandHelper = require ("./utils/commandHelper");
+import ICommand = tacoUtils.Commands.ICommand;
 
 interface IScenarioList {
     [scenario: number]: string;
@@ -172,7 +172,7 @@ describe("taco create", function (): void {
     }
 
     function runScenarioWithExpectedFileCount(scenario: number, expectedFileCount: number, tacoJsonFileContents?: IKeyValuePair<string>): Q.Promise<any> {
-        var create: TacoCommandBase = commandHelper.getCommand("create");
+        var create: ICommand = CommandHelper.getCommand("create");
 
         return create.run(makeICommandData(scenario, successScenarios))
             .then(function (): void {
@@ -197,7 +197,7 @@ describe("taco create", function (): void {
     }
 
     function runFailureScenario<T>(scenario: number, expectedErrorCode?: T): Q.Promise<any> {
-        var create: TacoCommandBase = commandHelper.getCommand("create");
+        var create: ICommand = CommandHelper.getCommand("create");
 
         return create.run(makeICommandData(scenario, failureScenarios))
             .then(function (): Q.Promise<any> {
@@ -471,7 +471,7 @@ describe("taco create", function (): void {
                 original: createCommandLineArguments,
                 remain: createCommandLineArguments.slice()
             };
-            var create: TacoCommandBase = commandHelper.getCommand("create");
+            var create: ICommand = CommandHelper.getCommand("create");
             create.run(commandData).done(() => {
                 var expected : string = expectedMessages.join("\n");
 
@@ -646,7 +646,7 @@ describe("taco create", function (): void {
         var cliVersion: string = require("../package.json").version;
 
         function createProjectAndVerifyTelemetryProps(args: string[], expectedProperties: TacoUtility.ICommandTelemetryProperties, done: MochaDone): void {
-            var create: TacoCommandBase = commandHelper.getCommand("create");
+            var create: ICommand = CommandHelper.getCommand("create");
             var commandData: tacoUtils.Commands.ICommandData = {
                 options: {},
                 original: args,

--- a/src/taco-cli/test/emulate.ts
+++ b/src/taco-cli/test/emulate.ts
@@ -38,10 +38,10 @@ import BuildInfo = TacoUtility.BuildInfo;
 import Command = buildAndRunTelemetry.Command;
 import utils = TacoUtility.UtilHelper;
 
-import commandHelper = require ("./utils/commandHelper");
-import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+import CommandHelper = require ("./utils/commandHelper");
+import ICommand = TacoUtility.Commands.ICommand;
 
-var create: TacoCommandBase = commandHelper.getCommand("create");
+var create: ICommand = CommandHelper.getCommand("create");
 
 describe("taco emulate", function (): void {
     var testHttpServer: http.Server;
@@ -109,7 +109,7 @@ describe("taco emulate", function (): void {
     });
 
     var emulateRun: (args: string[]) => Q.Promise<TacoUtility.ICommandTelemetryProperties> = function (args: string[]): Q.Promise<TacoUtility.ICommandTelemetryProperties> {
-        var emulate: TacoCommandBase = commandHelper.getCommand("emulate");
+        var emulate: ICommand = CommandHelper.getCommand("emulate");
         return emulate.run({
             options: {},
             original: args,

--- a/src/taco-cli/test/emulate.ts
+++ b/src/taco-cli/test/emulate.ts
@@ -28,10 +28,8 @@ import querystring = require ("querystring");
 import rimraf = require ("rimraf");
 
 import buildAndRunTelemetry = require ("./buildAndRunTelemetry");
-import createMod = require ("../cli/create");
 import kitHelper = require ("../cli/utils/kitHelper");
 import resources = require ("../resources/resourceManager");
-import emulateMod = require ("../cli/emulate");
 import ServerMock = require ("./utils/serverMock");
 import RemoteMock = require ("./utils/remoteMock");
 import TacoUtility = require ("taco-utils");
@@ -40,7 +38,10 @@ import BuildInfo = TacoUtility.BuildInfo;
 import Command = buildAndRunTelemetry.Command;
 import utils = TacoUtility.UtilHelper;
 
-var create: createMod = new createMod();
+import commandHelper = require ("./utils/commandHelper");
+import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+
+var create: TacoCommandBase = commandHelper.getCommand("create");
 
 describe("taco emulate", function (): void {
     var testHttpServer: http.Server;
@@ -108,7 +109,7 @@ describe("taco emulate", function (): void {
     });
 
     var emulateRun: (args: string[]) => Q.Promise<TacoUtility.ICommandTelemetryProperties> = function (args: string[]): Q.Promise<TacoUtility.ICommandTelemetryProperties> {
-        var emulate: emulateMod = new emulateMod();
+        var emulate: TacoCommandBase = commandHelper.getCommand("emulate");
         return emulate.run({
             options: {},
             original: args,

--- a/src/taco-cli/test/help.ts
+++ b/src/taco-cli/test/help.ts
@@ -27,10 +27,12 @@ import tacoUtils = require ("taco-utils");
 import Help = require ("../cli/help");
 import ms = require ("./utils/memoryStream");
 
-import commands = tacoUtils.Commands.ICommandData;
+import ICommandData = tacoUtils.Commands.ICommandData;
+import commandHelper = require ("./utils/commandHelper");
+import TacoCommandBase = tacoUtils.Commands.TacoCommandBase;
 
 describe("help for a command", function (): void {
-    var help: Help = new Help();
+    var help: TacoCommandBase = commandHelper.getCommand("help");
     // because of function overloading assigning "(buffer: string, cb?: Function) => boolean" as the type for
     // stdoutWrite just doesn't work
     var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later
@@ -38,7 +40,7 @@ describe("help for a command", function (): void {
     var previous: boolean;
 
     function helpRun(command: string): Q.Promise<any> {
-        var data: commands = {
+        var data: ICommandData = {
             options: {},
             original: [command],
             remain: [command]

--- a/src/taco-cli/test/help.ts
+++ b/src/taco-cli/test/help.ts
@@ -28,11 +28,11 @@ import Help = require ("../cli/help");
 import ms = require ("./utils/memoryStream");
 
 import ICommandData = tacoUtils.Commands.ICommandData;
-import commandHelper = require ("./utils/commandHelper");
-import TacoCommandBase = tacoUtils.Commands.TacoCommandBase;
+import CommandHelper = require ("./utils/commandHelper");
+import ICommand = tacoUtils.Commands.ICommand;
 
 describe("help for a command", function (): void {
-    var help: TacoCommandBase = commandHelper.getCommand("help");
+    var help: ICommand = CommandHelper.getCommand("help");
     // because of function overloading assigning "(buffer: string, cb?: Function) => boolean" as the type for
     // stdoutWrite just doesn't work
     var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later

--- a/src/taco-cli/test/kit.ts
+++ b/src/taco-cli/test/kit.ts
@@ -35,8 +35,8 @@ import TacoUtility = require ("taco-utils");
 import utils = TacoUtility.UtilHelper;
 
 import commands = tacoUtils.Commands.ICommandData;
-import commandHelper = require ("./utils/commandHelper");
-import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+import CommandHelper = require ("./utils/commandHelper");
+import ICommand = TacoUtility.Commands.ICommand;
 
 interface IKeyValuePair<T> {
     [key: string]: T;
@@ -46,7 +46,7 @@ describe("Kit", function (): void {
     this.timeout(20000);
 
     function kitRun(args: string[] = []): Q.Promise<TacoUtility.ICommandTelemetryProperties> {
-        var kit: TacoCommandBase = commandHelper.getCommand("kit");
+        var kit: ICommand = CommandHelper.getCommand("kit");
         var data: commands = {
             options: {},
             original: args,
@@ -65,7 +65,7 @@ describe("Kit", function (): void {
     var originalCwd: string;
 
     function createProject(args: string[], projectDir: string): Q.Promise<any> {
-        var create: TacoCommandBase = commandHelper.getCommand("create");
+        var create: ICommand = CommandHelper.getCommand("create");
         // Create a dummy test project with no platforms added
         utils.createDirectoryIfNecessary(tacoHome);
         process.chdir(tacoHome);

--- a/src/taco-cli/test/kit.ts
+++ b/src/taco-cli/test/kit.ts
@@ -29,14 +29,14 @@ import Q = require ("q");
 import rimraf = require ("rimraf");
 import util = require ("util");
 
-import createMod = require ("../cli/create");
-import kitMod = require ("../cli/kit");
 import kitHelper = require ("../cli/utils/kitHelper");
 import TacoUtility = require ("taco-utils");
 
 import utils = TacoUtility.UtilHelper;
 
 import commands = tacoUtils.Commands.ICommandData;
+import commandHelper = require ("./utils/commandHelper");
+import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
 
 interface IKeyValuePair<T> {
     [key: string]: T;
@@ -46,7 +46,7 @@ describe("Kit", function (): void {
     this.timeout(20000);
 
     function kitRun(args: string[] = []): Q.Promise<TacoUtility.ICommandTelemetryProperties> {
-        var kit: kitMod = new kitMod();
+        var kit: TacoCommandBase = commandHelper.getCommand("kit");
         var data: commands = {
             options: {},
             original: args,
@@ -65,7 +65,7 @@ describe("Kit", function (): void {
     var originalCwd: string;
 
     function createProject(args: string[], projectDir: string): Q.Promise<any> {
-        var create: createMod = new createMod();
+        var create: TacoCommandBase = commandHelper.getCommand("create");
         // Create a dummy test project with no platforms added
         utils.createDirectoryIfNecessary(tacoHome);
         process.chdir(tacoHome);

--- a/src/taco-cli/test/meta.ts
+++ b/src/taco-cli/test/meta.ts
@@ -18,7 +18,6 @@ import Q = require ("q");
 import should = require ("should");
 import util = require ("util");
 
-import Help = require ("../cli/help");
 import resources = require ("../resources/resourceManager");
 import Taco = require ("../cli/taco");
 import TacoErrorCodes = require ("../cli/tacoErrorCodes");
@@ -27,6 +26,9 @@ import Version = require ("../cli/version");
 
 import Commands = tacoUtils.Commands;
 import utils = tacoUtils.UtilHelper;
+
+import commandHelper = require ("./utils/commandHelper");
+import TacoCommandBase = tacoUtils.Commands.TacoCommandBase;
 
 interface ICommandOptionsAndArgsInfo {
     name: string;
@@ -56,7 +58,7 @@ describe("taco meta command tests: ", function (): void {
     var tacoInvalidArgs: string[][] = [["/?"], ["?"]];
 
     function runHelp(command: string): Q.Promise<any> {
-        var help: Help = new Help();
+        var help: TacoCommandBase = commandHelper.getCommand("help");
 
         // Construct CommandData and pass it as argument
         var original: string[] = [];

--- a/src/taco-cli/test/meta.ts
+++ b/src/taco-cli/test/meta.ts
@@ -27,8 +27,8 @@ import Version = require ("../cli/version");
 import Commands = tacoUtils.Commands;
 import utils = tacoUtils.UtilHelper;
 
-import commandHelper = require ("./utils/commandHelper");
-import TacoCommandBase = tacoUtils.Commands.TacoCommandBase;
+import CommandHelper = require ("./utils/commandHelper");
+import ICommand = tacoUtils.Commands.ICommand;
 
 interface ICommandOptionsAndArgsInfo {
     name: string;
@@ -58,7 +58,7 @@ describe("taco meta command tests: ", function (): void {
     var tacoInvalidArgs: string[][] = [["/?"], ["?"]];
 
     function runHelp(command: string): Q.Promise<any> {
-        var help: TacoCommandBase = commandHelper.getCommand("help");
+        var help: ICommand = CommandHelper.getCommand("help");
 
         // Construct CommandData and pass it as argument
         var original: string[] = [];

--- a/src/taco-cli/test/platformHelper.ts
+++ b/src/taco-cli/test/platformHelper.ts
@@ -29,12 +29,12 @@ import resources = require ("../resources/resourceManager");
 import PlatformHelper = require ("../cli/utils/platformHelper");
 import RemoteMock = require ("./utils/remoteMock");
 import TacoUtility = require ("taco-utils");
-import commandHelper = require ("./utils/commandHelper");
-import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+import CommandHelper = require ("./utils/commandHelper");
+import ICommand = TacoUtility.Commands.ICommand;
 
 import utils = TacoUtility.UtilHelper;
 
-var create: TacoCommandBase = commandHelper.getCommand("create");
+var create: ICommand = CommandHelper.getCommand("create");
 describe("taco PlatformHelper", function (): void {
     var tacoHome: string = path.join(os.tmpdir(), "taco-cli", "PlatformHelper");
     var originalCwd: string;

--- a/src/taco-cli/test/platformHelper.ts
+++ b/src/taco-cli/test/platformHelper.ts
@@ -24,16 +24,17 @@ import path = require ("path");
 import Q = require ("q");
 import rimraf = require ("rimraf");
 
-import createMod = require ("../cli/create");
 import kitHelper = require ("../cli/utils/kitHelper");
 import resources = require ("../resources/resourceManager");
 import PlatformHelper = require ("../cli/utils/platformHelper");
 import RemoteMock = require ("./utils/remoteMock");
 import TacoUtility = require ("taco-utils");
+import commandHelper = require ("./utils/commandHelper");
+import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
 
 import utils = TacoUtility.UtilHelper;
 
-var create: createMod = new createMod();
+var create: TacoCommandBase = commandHelper.getCommand("create");
 describe("taco PlatformHelper", function (): void {
     var tacoHome: string = path.join(os.tmpdir(), "taco-cli", "PlatformHelper");
     var originalCwd: string;

--- a/src/taco-cli/test/platformPlugin.ts
+++ b/src/taco-cli/test/platformPlugin.ts
@@ -35,14 +35,14 @@ import kitHelper = require ("../cli/utils/kitHelper");
 import resources = require ("../resources/resourceManager");
 import TacoUtility = require ("taco-utils");
 import ms = require("./utils/memoryStream");
-import commandHelper = require ("./utils/commandHelper");
-import TacoCommandBase = tacoUtility.Commands.TacoCommandBase;
+import CommandHelper = require ("./utils/commandHelper");
+import ICommand = tacoUtility.Commands.ICommand;
 
 import utils = TacoUtility.UtilHelper;
 
-var platformCommand: TacoCommandBase = commandHelper.getCommand("platform");
-var pluginCommand: TacoCommandBase = commandHelper.getCommand("plugin");
-var createCommand: TacoCommandBase = commandHelper.getCommand("create");
+var platformCommand: ICommand = CommandHelper.getCommand("platform");
+var pluginCommand: ICommand = CommandHelper.getCommand("plugin");
+var createCommand: ICommand = CommandHelper.getCommand("create");
 
 var testKitId: string = "5.1.1-Kit";
 

--- a/src/taco-cli/test/platformPlugin.ts
+++ b/src/taco-cli/test/platformPlugin.ts
@@ -31,24 +31,18 @@ import tacoUtility = require("taco-utils");
 import util = require ("util");
 import wrench = require ("wrench");
 
-import Platform = require ("../cli/platform");
-import Plugin = require ("../cli/plugin");
-import Create = require ("../cli/create");
 import kitHelper = require ("../cli/utils/kitHelper");
 import resources = require ("../resources/resourceManager");
 import TacoUtility = require ("taco-utils");
 import ms = require("./utils/memoryStream");
-import commands = tacoUtility.Commands;
+import commandHelper = require ("./utils/commandHelper");
+import TacoCommandBase = tacoUtility.Commands.TacoCommandBase;
 
 import utils = TacoUtility.UtilHelper;
 
-var platformCommand: Platform = new Platform();
-platformCommand.info = <commands.ICommandInfo> {};
-platformCommand.info.aliases = {"rm": "remove", "ls": "list"};
-var pluginCommand: Plugin = new Plugin();
-pluginCommand.info = <commands.ICommandInfo> {};
-pluginCommand.info.aliases = { "rm": "remove", "ls": "list" };
-var createCommand: Create = new Create();
+var platformCommand: TacoCommandBase = commandHelper.getCommand("platform");
+var pluginCommand: TacoCommandBase = commandHelper.getCommand("plugin");
+var createCommand: TacoCommandBase = commandHelper.getCommand("create");
 
 var testKitId: string = "5.1.1-Kit";
 

--- a/src/taco-cli/test/remote.ts
+++ b/src/taco-cli/test/remote.ts
@@ -35,12 +35,12 @@ import RemoteMock = require ("./utils/remoteMock");
 import IRemoteServerSequence = require ("./utils/remoteServerSequence");
 import TacoUtility = require ("taco-utils");
 import ms = require ("./utils/memoryStream");
-import commandHelper = require ("./utils/commandHelper");
-import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+import CommandHelper = require ("./utils/commandHelper");
+import ICommand = TacoUtility.Commands.ICommand;
 
 import utils = TacoUtility.UtilHelper;
 
-var remote: TacoCommandBase = commandHelper.getCommand("remote");
+var remote: ICommand = CommandHelper.getCommand("remote");
 
 describe("taco remote", function(): void {
     var testHome: string = path.join(os.tmpdir(), "taco-cli", "setup");

--- a/src/taco-cli/test/remote.ts
+++ b/src/taco-cli/test/remote.ts
@@ -35,10 +35,12 @@ import RemoteMock = require ("./utils/remoteMock");
 import IRemoteServerSequence = require ("./utils/remoteServerSequence");
 import TacoUtility = require ("taco-utils");
 import ms = require ("./utils/memoryStream");
+import commandHelper = require ("./utils/commandHelper");
+import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
 
 import utils = TacoUtility.UtilHelper;
 
-var remote: RemoteMod = new RemoteMod();
+var remote: TacoCommandBase = commandHelper.getCommand("remote");
 
 describe("taco remote", function(): void {
     var testHome: string = path.join(os.tmpdir(), "taco-cli", "setup");

--- a/src/taco-cli/test/run.ts
+++ b/src/taco-cli/test/run.ts
@@ -40,10 +40,10 @@ import BuildInfo = TacoUtility.BuildInfo;
 import Command = buildAndRunTelemetry.Command;
 import utils = TacoUtility.UtilHelper;
 
-import commandHelper = require ("./utils/commandHelper");
-import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+import CommandHelper = require ("./utils/commandHelper");
+import ICommand = TacoUtility.Commands.ICommand;
 
-var create: TacoCommandBase = commandHelper.getCommand("create");
+var create: ICommand = CommandHelper.getCommand("create");
 
 describe("taco run", function (): void {
     this.timeout(60000); // The remote tests sometimes take some time to run
@@ -110,7 +110,7 @@ describe("taco run", function (): void {
     });
 
     var runRun: (args: string[]) => Q.Promise<TacoUtility.ICommandTelemetryProperties> = function (args: string[]): Q.Promise<TacoUtility.ICommandTelemetryProperties> {
-        var run: TacoCommandBase = commandHelper.getCommand("run");
+        var run: ICommand = CommandHelper.getCommand("run");
         return run.run({
             options: {},
             original: args,

--- a/src/taco-cli/test/run.ts
+++ b/src/taco-cli/test/run.ts
@@ -28,12 +28,10 @@ import querystring = require ("querystring");
 import rimraf = require ("rimraf");
 
 import buildAndRunTelemetry = require ("./buildAndRunTelemetry");
-import createMod = require ("../cli/create");
 import IHttpServerFunction = require ("./utils/httpServerFunction");
 import kitHelper = require ("../cli/utils/kitHelper");
 import IRemoteServerSequence = require ("./utils/remoteServerSequence");
 import resources = require ("../resources/resourceManager");
-import runMod = require ("../cli/run");
 import ServerMock = require ("./utils/serverMock");
 import RemoteMock = require ("./utils/remoteMock");
 import TacoUtility = require ("taco-utils");
@@ -42,7 +40,10 @@ import BuildInfo = TacoUtility.BuildInfo;
 import Command = buildAndRunTelemetry.Command;
 import utils = TacoUtility.UtilHelper;
 
-var create: createMod = new createMod();
+import commandHelper = require ("./utils/commandHelper");
+import TacoCommandBase = TacoUtility.Commands.TacoCommandBase;
+
+var create: TacoCommandBase = commandHelper.getCommand("create");
 
 describe("taco run", function (): void {
     this.timeout(60000); // The remote tests sometimes take some time to run
@@ -109,7 +110,7 @@ describe("taco run", function (): void {
     });
 
     var runRun: (args: string[]) => Q.Promise<TacoUtility.ICommandTelemetryProperties> = function (args: string[]): Q.Promise<TacoUtility.ICommandTelemetryProperties> {
-        var run: runMod = new runMod();
+        var run: TacoCommandBase = commandHelper.getCommand("run");
         return run.run({
             options: {},
             original: args,

--- a/src/taco-cli/test/utils/commandHelper.ts
+++ b/src/taco-cli/test/utils/commandHelper.ts
@@ -20,7 +20,7 @@ class CommandHelper {
     /**
      * Gets specified task object for use in testing.
      */
-    public static getCommand(name: string): commands.TacoCommandBase {
+    public static getCommand(name: string): commands.ICommand {
         return CommandHelper.commandsFactory.getTask(name, [], path.join(__dirname, "..", "..", "cli"));
     }
 }

--- a/src/taco-cli/test/utils/commandHelper.ts
+++ b/src/taco-cli/test/utils/commandHelper.ts
@@ -1,0 +1,28 @@
+﻿/**
+  * ******************************************************
+  *                                                       *
+  *   Copyright (C) Microsoft. All rights reserved.       *
+  *                                                       *
+  *******************************************************
+  */
+/// <reference path="../../../typings/tacoUtils.d.ts" />
+
+import path = require ("path");
+
+import tacoUtility = require ("taco-utils");
+
+import commands = tacoUtility.Commands;
+import CommandsFactory = commands.CommandFactory;
+
+class CommandHelper {
+    private static commandsFactory: CommandsFactory = new CommandsFactory(path.join(__dirname, "../../cli/commands.json"));
+
+    /**
+     * Gets specified task object for use in testing.
+     */
+    public static getCommand(name: string): commands.TacoCommandBase {
+        return CommandHelper.commandsFactory.getTask(name, [], path.join(__dirname, "..", "..", "cli"));
+    }
+}
+
+export = CommandHelper;


### PR DESCRIPTION
## Summary
The motivation for this change is to construct command objects for tests in the same way that we do for production code. In particular, alias testing needs command objects constructed with the commands.json file for correct aliasing.

## Changes
* Created static class CommandHelper which constructs the command object.
* Wherever we were new-ing command objects, a call to CommandHelper.getCommand is made.
* Clean up of no longer used imports.
