### PR TITLE
Changing the behavior so that dropLocation is just used as a variable to

### DIFF
--- a/src/gulpmain.ts
+++ b/src/gulpmain.ts
@@ -57,19 +57,19 @@ gulp.task("package", [], function (callback: gulp.TaskCallback): void {
     runSequence("build", "just-package", callback);
 });
 
-gulp.task("just-package", [], function (callback: gulp.TaskCallback): void {
-    runSequence("dev-package", "beta-package", "release-package", callback);
+gulp.task("just-package", [], function(callback: gulp.TaskCallback): void {
+    runSequence("beta-package", "release-package", "dev-package", callback);
 });
 
-gulp.task("dev-package", [], function(): Q.Promise<any> {
+gulp.task("dev-package", ["copy"], function(): Q.Promise<any> {
     return gulpUtils.package(buildConfig.buildPackages, allModules, "dev", options.drop || buildConfig.buildPackages);
 });
 
-gulp.task("beta-package", [], function(): Q.Promise<any> {
+gulp.task("beta-package", ["copy"], function(): Q.Promise<any> {
     return gulpUtils.package(buildConfig.buildPackages, allModules, "beta", options.drop || buildConfig.buildPackages);
 });
 
-gulp.task("release-package", [], function(): Q.Promise<any> {
+gulp.task("release-package", ["copy"], function(): Q.Promise<any> {
     return gulpUtils.package(buildConfig.buildPackages, allModules, "release", options.drop || buildConfig.buildPackages);
 });
 

--- a/tools/GulpUtils.ts
+++ b/tools/GulpUtils.ts
@@ -217,7 +217,7 @@ class GulpUtils {
                     });
                     return json;
                 }))
-            .pipe(gulp.dest(destPath)));
+            .pipe(gulp.dest(srcPath)));
     }
 
     private static updateDynamicDependencies(srcPath: string, buildType: string, destPath: string): Q.Promise<any> {
@@ -252,7 +252,7 @@ class GulpUtils {
                     return json;
                 }
             ))
-            .pipe(gulp.dest(destPath)));
+            .pipe(gulp.dest(srcPath)));
     }
 
     private static packageModules(srcPath: string, modules: string[], buildType: string, destPath: string): Q.Promise<any> {
@@ -285,9 +285,9 @@ class GulpUtils {
 
                     var targetPath: string = "";
                     if (buildType != "dev") {
-                        targetPath = path.resolve(destPath, buildType, tacoModule + ".tgz");
+                        targetPath = path.resolve(srcPath, buildType, tacoModule + ".tgz");
                     } else {
-                        targetPath = path.resolve(destPath, tacoModule + ".tgz");
+                        targetPath = path.resolve(srcPath, tacoModule + ".tgz");
                     }
                     var parentDir = path.dirname(targetPath);
                     if (!fs.existsSync(parentDir)) {


### PR DESCRIPTION
specify dependencies location but no actual files are dropped at
dropLocation
Moreover, fixing an issue where just-package fails because of previous
packaging artifacts