### PR TITLE
Updating to ios-sim version 5

### DIFF
--- a/src/taco-remote-lib/ios/ios.ts
+++ b/src/taco-remote-lib/ios/ios.ts
@@ -50,7 +50,7 @@ class IOSAgent implements ITargetPlatform {
         this.webDebugProxyPortMax = config.get("webDebugProxyPortMax") || 9322;
 
         if (utils.ArgsHelper.argToBool(config.get("allowsEmulate"))) {
-            process.env["PATH"] = path.resolve(__dirname, path.join("..", "node_modules", "ios-sim", "build", "release")) + ":" + process.env["PATH"];
+            process.env["PATH"] = path.resolve(__dirname, path.join("..", "node_modules", ".bin")) + ":" + process.env["PATH"];
             child_process.exec("which ios-sim", function (err: Error, stdout: Buffer, stderr: Buffer): void {
                 if (err) {
                     Logger.logError(resources.getString("IOSSimNotFound"));
@@ -152,7 +152,7 @@ class IOSAgent implements ITargetPlatform {
         var emulateProcess: child_process.ChildProcess = child_process.fork(path.join(__dirname, "iosEmulateHelper.js"), [], { silent: true });
         var emulateLogger: ProcessLogger = new ProcessLogger();
         emulateLogger.begin(buildInfo.buildDir, "emulate.log", buildInfo.buildLang, emulateProcess);
-        emulateProcess.send({ appDir: buildInfo.appDir, appName: cfg.id(), target: req.query.target }, null);
+        emulateProcess.send({ appDir: buildInfo.appDir, appName: cfg.id(), target: req.query.target, version: req.query.iOSVersion }, null);
 
         emulateProcess.on("message", function (result: { status: string; messageId: string; messageArgs?: any }): void {
             buildInfo.updateStatus(result.status, result.messageId, result.messageArgs);

--- a/src/taco-remote-lib/package.json
+++ b/src/taco-remote-lib/package.json
@@ -35,7 +35,7 @@
         "should": "4.3.0"
     },
     "optionalDependencies": {
-        "ios-sim": "^3.2.0"
+        "ios-sim": "^5.0.2"
     },
 
     "scripts": {


### PR DESCRIPTION
ios-sim 5 uses a different approach to specify a simulation target, but we still support all the same previous inputs. As part of this change we also now allow the iOS version to be specified, but if the target/version combination doesn't exist on the server then it will fail.