### PR TITLE
Adding a check for incompatible node/cordova versions

### DIFF
--- a/src/taco-remote-lib/ios/iosBuild.ts
+++ b/src/taco-remote-lib/ios/iosBuild.ts
@@ -19,6 +19,7 @@ import fs = require ("fs");
 import path = require ("path");
 import Q = require ("q");
 import rimraf = require ("rimraf");
+import semver = require ("semver");
 
 import Builder = require ("../common/builder");
 import plist = require ("./plist");
@@ -68,6 +69,12 @@ class IOSBuilder extends Builder {
     }
 
     protected beforePrepare(): Q.Promise<any> {
+        if (semver.lt(this.currentBuild["vcordova"], "5.3.3") && semver.gte(process.versions.node, "4.0.0")) {
+            var preferences = this.cfg.preferences();
+            if (preferences["target-device"] || preferences["deployment-target"]) {
+                throw new Error(resources.getString("UnsupportedCordovaAndNodeVersion"));
+            }
+        }
         return Q({});
     }
 

--- a/src/taco-remote-lib/package.json
+++ b/src/taco-remote-lib/package.json
@@ -27,7 +27,8 @@
         "q": "1.0.1",
         "rimraf": "2.2.6",
         "plist-with-patches": "0.5.1",
-        "taco-utils": "file:../taco-utils"
+        "taco-utils": "file:../taco-utils",
+        "semver": "^4.3.6"
     },
     "devDependencies": {
         "typescript": "~1.6.2",

--- a/src/taco-remote-lib/resources/en/resources.json
+++ b/src/taco-remote-lib/resources/en/resources.json
@@ -68,7 +68,7 @@
     "_UnsupportedPlatform.comment": "Message reported to the client when a request for an unsupported platform is made",
     "NoCordovaVersionSpecified": "No Cordova version specified!",
     "_NoCordovaVersionSpecified.comment": "Error reported when trying to build without any version specified",
-    "UnsupportedCordovaAndNodeVersion": "Unable to build using Cordova earlier than 5.3.3 when on node version 4.0.0 and higher and also specifying deployment-target or target-device preferences in config.xml",
+    "UnsupportedCordovaAndNodeVersion": "Incompatible configuration: Unable to build using Cordova < 5.3.3 and Node >= 4.0.0, with deployment-target or target-device specified in the config.xml",
     "_UnsupportedCordovaAndNodeVersion.comment": "Error reported when trying to build cordova < 5.3.3 on node >= 4.0.0 when it would result in a deadlock.",
 
     "DoneBuilding": "Done building {0}",

--- a/src/taco-remote-lib/resources/en/resources.json
+++ b/src/taco-remote-lib/resources/en/resources.json
@@ -68,6 +68,8 @@
     "_UnsupportedPlatform.comment": "Message reported to the client when a request for an unsupported platform is made",
     "NoCordovaVersionSpecified": "No Cordova version specified!",
     "_NoCordovaVersionSpecified.comment": "Error reported when trying to build without any version specified",
+    "UnsupportedCordovaAndNodeVersion": "Unable to build using Cordova earlier than 5.3.3 when on node version 4.0.0 and higher and also specifying deployment-target or target-device preferences in config.xml",
+    "_UnsupportedCordovaAndNodeVersion.comment": "Error reported when trying to build cordova < 5.3.3 on node >= 4.0.0 when it would result in a deadlock.",
 
     "DoneBuilding": "Done building {0}",
     "_DoneBuilding.comment": "Message logged when a build is completed successfully. {0} is the build number",


### PR DESCRIPTION
Cordova <5.3.3 breaks on node >=4.0.0 if the deployment-target or target-device preferences are specified in config.xml.
When run under remotebuild, this shows up as a deadlock which holds up all further processing. Now we check for
this combination and proactively reject the build with a message to the end user.
Addresses issue #96 