### PR TITLE
Improving error handling with remotebuild

### DIFF
--- a/src/taco-cli/cli/remote.ts
+++ b/src/taco-cli/cli/remote.ts
@@ -341,7 +341,9 @@ class Remote extends commands.TacoCommandBase {
     }
 
     private static getFriendlyHttpError(error: any, host: string, port: number, url: string, secure: boolean): Error {
-        if (error.code.indexOf("CERT_") !== -1) {
+        if (!error.code) {
+            return errorHelper.wrap(TacoErrorCodes.ErrorHttpGet, error, url);
+        } else if (error.code.indexOf("CERT_") !== -1) {
             return errorHelper.get(TacoErrorCodes.InvalidRemoteBuildClientCert);
         } else if (error.code === "ECONNREFUSED") {
             return errorHelper.get(TacoErrorCodes.CommandRemoteConnectionRefused, util.format("%s://%s:%s", secure ? "https" : "http", host, port));

--- a/src/taco-cli/cli/remoteBuild/remoteBuildClientHelper.ts
+++ b/src/taco-cli/cli/remoteBuild/remoteBuildClientHelper.ts
@@ -236,7 +236,9 @@ class RemoteBuildClientHelper {
      * Convert errors from error codes to localizable strings
      */
     private static errorFromRemoteBuildServer(serverUrl: string, requestError: any, fallbackErrorCode: TacoErrorCodes): Error {
-        if (requestError.code.indexOf("CERT_") !== -1) {
+        if (!requestError.code) {
+            return errorHelper.wrap(fallbackErrorCode, <Error> requestError, serverUrl);
+        } else if (requestError.code.indexOf("CERT_") !== -1) {
             return errorHelper.get(TacoErrorCodes.InvalidRemoteBuildClientCert);
         } else if (serverUrl.indexOf("https://") === 0 && requestError.code === "ECONNRESET") {
             return errorHelper.get(TacoErrorCodes.RemoteBuildSslConnectionReset, serverUrl);


### PR DESCRIPTION
Some errors when attempting HTTP[S] communication will not have a "code" property, for example if a HTTPS connection is rejected because the server's hostname does not match the names on the certificate. This change make sure that we give appropriate errors rather than crashing.