### PR TITLE
Project update (taco.json update) should happen only if user chooses "y" when presented with the choice

### DIFF
--- a/src/taco-cli/cli/create.ts
+++ b/src/taco-cli/cli/create.ts
@@ -87,8 +87,13 @@ class Create extends commands.TacoCommandBase {
 
                 var kitProject: boolean = self.isKitProject();
                 var valueToSerialize: string = kitProject ? self.commandParameters.data.options["kit"] : self.commandParameters.data.options["cordova"];
+                var tacoJsonEditParams: projectHelper.ITacoJsonEditParams = {
+                    projectPath: self.commandParameters.cordovaParameters.projectPath,
+                    isKitProject: kitProject,
+                    version: valueToSerialize
+                };
 
-                return projectHelper.createTacoJsonFile(self.commandParameters.cordovaParameters.projectPath, kitProject, valueToSerialize);
+                return projectHelper.editTacoJsonFile(tacoJsonEditParams);
             })
             .then(function (): Q.Promise<any> {
                 self.finalize(templateDisplayName);

--- a/src/taco-cli/cli/kit.ts
+++ b/src/taco-cli/cli/kit.ts
@@ -647,7 +647,7 @@ class Kit extends commands.TacoCommandBase {
                             return Kit.promptAndUpdateProject(tacoJsonEditParams, installedPlatformVersions,
                                 installedPluginVersions, platformVersionUpdates, pluginVersionUpdates);
                         } else {
-                            return Q.resolve({});
+                            return projectHelper.editTacoJsonFile(tacoJsonEditParams);
                         }
                     });
                 });
@@ -712,7 +712,7 @@ class Kit extends commands.TacoCommandBase {
                         Kit.printListOfComponentsSkippedForUpdate(nonUpdatablePlugins);
                         return Kit.promptAndUpdateProject(tacoJsonEditParams, platformVersions, pluginsToUpdate);
                     } else {
-                        return Q.resolve({});
+                        return projectHelper.editTacoJsonFile(tacoJsonEditParams);
                     }
                 });
             });

--- a/src/taco-cli/cli/kit.ts
+++ b/src/taco-cli/cli/kit.ts
@@ -89,7 +89,7 @@ class Kit extends commands.TacoCommandBase {
     /**
      * Prompts for update and updates the project on a affirmative response
      */
-    public static promptAndUpdateProject(updateToCliProject: boolean, installedPlatformVersions: IDictionary<string>, installedPluginVersions: IDictionary<string>,
+    public static promptAndUpdateProject(editParams: projectHelper.ITacoJsonEditParams, installedPlatformVersions: IDictionary<string>, installedPluginVersions: IDictionary<string>,
         platformVersionUpdates: IDictionary<string> = null, pluginVersionUpdates: IDictionary<string> = null): Q.Promise<any> {
         logger.logLine();
         return Kit.promptUser(resources.getString("CommandKitSelectProjectUpdatePrompt"))
@@ -98,7 +98,7 @@ class Kit extends commands.TacoCommandBase {
                 answer = answer.toLowerCase();
                 if (resources.getString("PromptResponseYes").split("\n").indexOf(answer) !== -1) {
                     logger.logLine();
-                    return Kit.updateProject(updateToCliProject, installedPlatformVersions, installedPluginVersions, platformVersionUpdates, pluginVersionUpdates);
+                    return Kit.updateProject(editParams, installedPlatformVersions, installedPluginVersions, platformVersionUpdates, pluginVersionUpdates);
                 }
             }
         });
@@ -402,7 +402,7 @@ class Kit extends commands.TacoCommandBase {
     /**
      * Updates the project compoenents - plugins/platforms added to the project - Removes and adds platforms
      */
-    private static updateComponents(updateToCliProject: boolean, components: IDictionary<string>, componentType: ProjectComponentType): Q.Promise<any> {
+    private static updateComponents(editParams: projectHelper.ITacoJsonEditParams, components: IDictionary<string>, componentType: ProjectComponentType): Q.Promise<any> {
         assert(componentType === ProjectComponentType.Platform || componentType === ProjectComponentType.Plugin);
         if (!components || Object.keys(components).length === 0) {
             return Q({});
@@ -423,9 +423,9 @@ class Kit extends commands.TacoCommandBase {
            return Object.keys(components).reduce<Q.Promise<any>>(function (soFar: Q.Promise<any>, componentName: string): Q.Promise<any> {
                 return soFar.then(function (): Q.Promise<any> {
                     // No override on the case of CLI project update - Cordova CLI gets its pinned version
-                    var componentOverride: string = updateToCliProject ? componentName : componentName + "@" + components[componentName];
+                    var componentOverride: string = editParams.isKitProject ? componentName + "@" + components[componentName] : componentName;
                     // Do not save in the case of updating to CLI project
-                    downloadOptions.save = !updateToCliProject;
+                    downloadOptions.save = editParams.isKitProject;
                     return Kit.invokeComponentCommandSilent(command, "add", [componentOverride], downloadOptions);
                 });
             }, Q({}));
@@ -435,11 +435,16 @@ class Kit extends commands.TacoCommandBase {
     /**
      * Updates the platforms and plugins added to the project - after a kit/cli change
      */
-    private static updateProject(updateToCliProject: boolean, installedPlatformVersions: IDictionary<string>, installedPluginVersions: IDictionary<string>,
+    private static updateProject(editParams: projectHelper.ITacoJsonEditParams, installedPlatformVersions: IDictionary<string>, installedPluginVersions: IDictionary<string>,
         platformVersionUpdates: IDictionary<string> = null, pluginVersionUpdates: IDictionary<string> = null): Q.Promise<any> {
-        return Kit.updateComponents(updateToCliProject, platformVersionUpdates || installedPlatformVersions, ProjectComponentType.Platform)
+        logger.log(resources.getString("CommandKitSelectStatusUpdatingTacoJson"));
+        // First, update the taco.json to reflect the new CLI/kit version
+        // Then go ahead and update the platforms and plugins
+        return projectHelper.editTacoJsonFile(editParams)
         .then(function (): Q.Promise<any> {
-            return Kit.updateComponents(updateToCliProject, pluginVersionUpdates || installedPluginVersions, ProjectComponentType.Plugin);
+            return Kit.updateComponents(editParams, platformVersionUpdates || installedPlatformVersions, ProjectComponentType.Platform);
+        }).then(function (): Q.Promise<any> {
+            return Kit.updateComponents(editParams, pluginVersionUpdates || installedPluginVersions, ProjectComponentType.Plugin);
         });
     }
 
@@ -607,10 +612,14 @@ class Kit extends commands.TacoCommandBase {
         var installedPlatformVersions: IDictionary<string>;
         var installedPluginVersions: IDictionary<string>;
         var currentCliVersion: string;
+        var tacoJsonEditParams: projectHelper.ITacoJsonEditParams = {
+            projectPath: projectPath,
+            isKitProject: true,
+            version: kitId
+        };
 
         // Query the installed platform/plugin versions, non-updatable plugin info (child plugins/plugins that were installed from GIT/local file system) and over-write taco.json with the new kit ID
-        return Q.all([projectHelper.getInstalledPlatformVersions(projectPath), projectHelper.getInstalledPluginVersions(projectPath), projectHelper.getNonUpdatablePlugins(projectPath),
-            projectHelper.createTacoJsonFile(projectPath, true, kitId)])
+        return Q.all([projectHelper.getInstalledPlatformVersions(projectPath), projectHelper.getInstalledPluginVersions(projectPath), projectHelper.getNonUpdatablePlugins(projectPath)])
         .spread<any>(function (platformVersions: IDictionary<string>, pluginVersions: IDictionary<string>, nonUpdatablePlugins: string[]): Q.Promise<any> {
             installedPlatformVersions = platformVersions;
             installedPluginVersions = Kit.filterUpdatablePluginVerions(pluginVersions, nonUpdatablePlugins);
@@ -624,7 +633,7 @@ class Kit extends commands.TacoCommandBase {
                         var projectRequiresUpdate: boolean = Kit.projectComponentNeedsUpdate(installedPlatformVersions, platformVersionUpdates) || Kit.projectComponentNeedsUpdate(installedPluginVersions, pluginVersionUpdates);
                         if (projectRequiresUpdate) {
                             Kit.printListOfComponentsSkippedForUpdate(nonUpdatablePlugins);
-                            return Kit.promptAndUpdateProject(false, installedPlatformVersions,
+                            return Kit.promptAndUpdateProject(tacoJsonEditParams, installedPlatformVersions,
                                 installedPluginVersions, platformVersionUpdates, pluginVersionUpdates);
                         } else {
                             return Q.resolve({});
@@ -672,9 +681,15 @@ class Kit extends commands.TacoCommandBase {
      * Changes the current Cordova CLI used for the project at {projectPath} to {cli}
      */
     private static selectCli(projectPath: string, projectInfo: projectHelper.IProjectInfo, newCliVersion: string): Q.Promise<any> {
+        var tacoJsonEditParams: projectHelper.ITacoJsonEditParams = {
+            projectPath: projectPath,
+            isKitProject: false,
+            version: newCliVersion
+        };
+
         return Kit.validateCliVersion(newCliVersion)
         .then(function (): Q.Promise<any> {
-            return Q.all([projectHelper.getInstalledPlatformVersions(projectPath), projectHelper.getInstalledPluginVersions(projectPath), projectHelper.getNonUpdatablePlugins(projectPath), projectHelper.createTacoJsonFile(projectPath, false, newCliVersion)])
+            return Q.all([projectHelper.getInstalledPlatformVersions(projectPath), projectHelper.getInstalledPluginVersions(projectPath), projectHelper.getNonUpdatablePlugins(projectPath)])
             .spread<any>(function (platformVersions: IDictionary<string>, pluginVersions: IDictionary<string>, nonUpdatablePlugins: string[]): Q.Promise<any> {
                 var pluginsToUpdate: IDictionary<string> = Kit.filterUpdatablePluginVerions(pluginVersions, nonUpdatablePlugins);
                 return Kit.getCliversion(projectInfo)
@@ -684,7 +699,7 @@ class Kit extends commands.TacoCommandBase {
                     var projectRequiresUpdate: boolean = ((platformVersions && Object.keys(platformVersions).length > 0) || (pluginVersions && Object.keys(pluginVersions).length > 0)) ? true : false;
                     if (projectRequiresUpdate) {
                         Kit.printListOfComponentsSkippedForUpdate(nonUpdatablePlugins);
-                        return Kit.promptAndUpdateProject(true, platformVersions, pluginsToUpdate);
+                        return Kit.promptAndUpdateProject(tacoJsonEditParams, platformVersions, pluginsToUpdate);
                     } else {
                         return Q.resolve({});
                     }

--- a/src/taco-cli/cli/platform.ts
+++ b/src/taco-cli/cli/platform.ts
@@ -127,6 +127,7 @@ class Platform extends commandBase.PlatformPluginCommandBase {
             break;
 
             case CommandOperationStatus.Success: {
+                logger.logLine();
                 this.printSuccessMessage(platforms, operation);
                 break;
             }

--- a/src/taco-cli/cli/plugin.ts
+++ b/src/taco-cli/cli/plugin.ts
@@ -94,8 +94,6 @@ class Plugin extends commandBase.PlatformPluginCommandBase {
                 });
             }, Q({}));
         }).then(function (): Q.Promise<any> {
-            // Set target and print status message
-            self.printStatusMessage(targets, self.cordovaCommandParams.subCommand, CommandOperationStatus.InProgress);
             self.cordovaCommandParams.targets = targets;
             return Q.resolve(pluginInfoToPersist);
         });
@@ -142,35 +140,9 @@ class Plugin extends commandBase.PlatformPluginCommandBase {
         }
 
         switch (status) {
-            case CommandOperationStatus.InProgress: {
-                this.printInProgressMessage(plugins, operation);
-            }
-            break;
-
             case CommandOperationStatus.Success: {
+                logger.logLine();
                 this.printSuccessMessage(plugins, operation);
-            }
-            break;
-        }
-    }
-
-    /**
-     * Prints the plugin addition/removal operation progress message
-     */
-    private printInProgressMessage(plugins: string, operation: string): void {
-        switch (this.resolveAlias(operation)) {
-            case "add": {
-                logger.log(resources.getString("CommandPluginStatusAdding", plugins));
-            }
-            break;
-
-            case "remove": {
-                logger.log(resources.getString("CommandPluginStatusRemoving", plugins));
-            }
-            break;
-
-            case "update": {
-                logger.log(resources.getString("CommandPluginStatusUpdating", plugins));
             }
             break;
         }

--- a/src/taco-cli/cli/utils/projectHelper.ts
+++ b/src/taco-cli/cli/utils/projectHelper.ts
@@ -44,15 +44,15 @@ class ProjectHelper {
      *  Helper to create the taco.json file in the project root {projectPath}. Invoked by
      *  the create command handler after the actual project creation  
      */
-    public static createTacoJsonFile(projectPath: string, isKitProject: boolean, versionValue: string): Q.Promise<any> {
+    public static editTacoJsonFile(editParams: ProjectHelper.ITacoJsonEditParams): Q.Promise<any> {
         ProjectHelper.cachedProjectInfo = null;
         ProjectHelper.cachedProjectFilePath = null;
         var deferred: Q.Deferred<any> = Q.defer<any>();
-        var tacoJsonPath: string = path.resolve(projectPath, ProjectHelper.TACO_JSON_FILENAME);
+        var tacoJsonPath: string = path.resolve(editParams.projectPath, ProjectHelper.TACO_JSON_FILENAME);
         var tacoJson: ProjectHelper.ITacoJsonMetadata = fs.existsSync(tacoJsonPath) ? require (tacoJsonPath) : {};
 
-        if (isKitProject) {
-           return ProjectHelper.parseKitId(versionValue)
+        if (editParams.isKitProject) {
+           return ProjectHelper.parseKitId(editParams.version)
            .then(function (kitId: string): Q.Promise<any> {
                 tacoJson.kit = kitId;
                 return kitHelper.getValidCordovaCli(tacoJson.kit);
@@ -65,12 +65,12 @@ class ProjectHelper {
                 delete tacoJson.kit;
             }
 
-            if (!versionValue) {
+            if (!editParams.version) {
                 deferred.reject(errorHelper.get(TacoErrorCodes.CommandCreateTacoJsonFileCreationError));
                 return deferred.promise;
             }
 
-            tacoJson["cordova-cli"] = versionValue;
+            tacoJson["cordova-cli"] = editParams.version;
             return ProjectHelper.createJsonFileWithContents(tacoJsonPath, tacoJson);
         }
     }
@@ -365,6 +365,12 @@ class ProjectHelper {
 }
 
 module ProjectHelper {
+    export interface ITacoJsonEditParams {
+        projectPath: string;
+        isKitProject: boolean;
+        version: string;
+    }
+
     export interface ITacoJsonMetadata {
         kit?: string;
         "cordova-cli"?: string;

--- a/src/taco-cli/resources/en/resources.json
+++ b/src/taco-cli/resources/en/resources.json
@@ -170,6 +170,8 @@
     "_CommandKitSelectStatusUpdatingPlatforms.comment": "Status message on updating platforms",
     "CommandKitSelectStatusUpdatingPlugins": "Updating plugins...",
     "_CommandKitSelectStatusUpdatingPlugins.comment": "Status message on updating plugins",
+    "CommandKitSelectStatusUpdatingTacoJson": "Updating taco.json...",
+    "_CommandKitSelectStatusUpdatingTacoJson.comment": "Status message on updating taco.json file of the project",
     "CommandKitSelectStatusSuccess": "<success>Success!</success>",
     "_CommandKitSelectStatusSuccess.comment": "Status message on successfully updating platforms and plugins",
     "CommandKitListCurrentCordovaCLI": "<bold>Current Cordova CLI</bold>: {0}",
@@ -307,13 +309,9 @@
     "_CommandPluginWithIdStatusAdded.comment": "Status message after successfully installed plugin {0}",
     "CommandPluginStatusRemoved": "<success>Success!</success> Plugin <highlight>{0}</highlight> removed<br/>",
     "_CommandPluginStatusRemoved.comment": "Status message after successfully removing plugin {0}",
-    "CommandPluginStatusAdding": "Fetching plugin \"<highlight>{0}</highlight>\" via npm.<br/>",
-    "_CommandPluginStatusAdding.comment": "Status message shown while adding a platform {0} of version {1} from NPM",
     "CommandPluginTestedPlatforms": "The plugin <highlight>{0}</highlight> has been validated on platform(s) - {1}.<br/>",
     "_CommandPluginTestedPlatforms.comment": "Status message regarding the tested platforms while adding a plugin {0}",
-    "CommandPluginStatusRemoving": "Removing plugin <highlight>{0}</highlight> from Cordova project...<br/>",
-    "_CommandPluginStatusRemoving.comment": "Status message shown while removing a plugin {0} from the project",
-
+    
     "CommandBuildDescription": "Build the project for a given platform",
     "_CommandBuildDescription.comment": "Description for 'taco build'",
     "CommandBuildPlatformDescription": "The platform that you wish to build",

--- a/src/taco-cli/test/kit.ts
+++ b/src/taco-cli/test/kit.ts
@@ -299,7 +299,7 @@ describe("Kit command : ", function (): void {
 
         it("'taco kit select --cordova {CLI-VERSION}' on a project with a platform added, should execute with no errors", function (done: MochaDone): void {
             KitMod.yesOrNoHandler = getMockYesOrNoHandler(done, utils.emptyMethod, "PromptResponseNo");
-            runKitCommandSuccessCaseAndVerifyTacoJson(["select", "--cordova", "4.3.1"], tacoJsonPath, expectedCliTacoJsonKeyValues1)
+            runKitCommandSuccessCaseAndVerifyTacoJson(["select", "--cordova", "4.3.1"], tacoJsonPath, expectedKitTacoJsonKeyValues/*expectedCliTacoJsonKeyValues1*/)
                 .then(function(telemetryParameters: TacoUtility.ICommandTelemetryProperties): void {
                     var expected: TacoUtility.ICommandTelemetryProperties = {
                         subCommand: { isPii: false, value: "select" },
@@ -340,19 +340,19 @@ describe("Kit command : ", function (): void {
         });
 
         it("'taco kit select --kit {kit-ID}' followed by a positive response to platform/plugin update query should should execute with no errors", function (done: MochaDone): void {
-            KitMod.yesOrNoHandler = getMockYesOrNoHandler(done, utils.emptyMethod, "PromptResponseNo");
+            KitMod.yesOrNoHandler = getMockYesOrNoHandler(done, utils.emptyMethod, "PromptResponseYes");
             return addTestPluginsToProject(cliProjectpath)
             .then(function (): Q.Promise<any> {
-                return runKitCommandSuccessCaseAndVerifyTacoJson(["select", "--kit", "5.1.1-Kit"], tacoJsonPath, expectedKitTacoJsonKeyValues)
-                .then(function(telemetryParameters: TacoUtility.ICommandTelemetryProperties): void {
-                    var expected = {
-                        subCommand: { isPii: false, value: "select" },
-                        "options.kit": { isPii: false, value: "5.1.1-Kit" }
-                    };
-                    telemetryParameters.should.be.eql(expected);
-                }).then(() => {
-                    TestProjectHelper.checkPlatformVersions(expectedKitPlatformVersion, cliProjectpath);
-                });
+                return runKitCommandSuccessCaseAndVerifyTacoJson(["select", "--kit", "5.1.1-Kit"], tacoJsonPath, expectedKitTacoJsonKeyValues);
+            })
+            .then(function(telemetryParameters: TacoUtility.ICommandTelemetryProperties): void {
+                var expected = {
+                    subCommand: { isPii: false, value: "select" },
+                    "options.kit": { isPii: false, value: "5.1.1-Kit" }
+                };
+                telemetryParameters.should.be.eql(expected);
+            }).then(() => {
+                TestProjectHelper.checkPlatformVersions(expectedKitPlatformVersion, cliProjectpath);
             }).done(() => done(), done);
         });
     });

--- a/src/taco-cli/test/kit.ts
+++ b/src/taco-cli/test/kit.ts
@@ -85,6 +85,10 @@ describe("Kit command : ", function (): void {
         android: "4.0.2"
     };
 
+    var expectedKitPluginVersion: IKeyValuePair<string> = {
+        "cordova-plugin-camera": "1.2.0"
+    };
+
     function createProject(args: string[], projectDir: string): Q.Promise<any> {
         var create: ICommand = CommandHelper.getCommand("create");
         // Create a dummy test project with no platforms added
@@ -299,7 +303,7 @@ describe("Kit command : ", function (): void {
 
         it("'taco kit select --cordova {CLI-VERSION}' on a project with a platform added, should execute with no errors", function (done: MochaDone): void {
             KitMod.yesOrNoHandler = getMockYesOrNoHandler(done, utils.emptyMethod, "PromptResponseNo");
-            runKitCommandSuccessCaseAndVerifyTacoJson(["select", "--cordova", "4.3.1"], tacoJsonPath, expectedKitTacoJsonKeyValues/*expectedCliTacoJsonKeyValues1*/)
+            runKitCommandSuccessCaseAndVerifyTacoJson(["select", "--cordova", "4.3.1"], tacoJsonPath, expectedKitTacoJsonKeyValues)
                 .then(function(telemetryParameters: TacoUtility.ICommandTelemetryProperties): void {
                     var expected: TacoUtility.ICommandTelemetryProperties = {
                         subCommand: { isPii: false, value: "select" },
@@ -351,8 +355,8 @@ describe("Kit command : ", function (): void {
                     "options.kit": { isPii: false, value: "5.1.1-Kit" }
                 };
                 telemetryParameters.should.be.eql(expected);
-            }).then(() => {
                 TestProjectHelper.checkPlatformVersions(expectedKitPlatformVersion, cliProjectpath);
+                TestProjectHelper.checkPluginVersions(expectedKitPluginVersion, cliProjectpath);
             }).done(() => done(), done);
         });
     });


### PR DESCRIPTION
1. Taco JSON should be updated only if user chose to update the project when presented with the choice
2. Fixing redundant status printing done when plugins are added/removed/updated