### PR TITLE
Changed calls to JSON.parse(fs.readFileSync()) to use 'utf8' so we don't need to cast the result of reading the file

### DIFF
--- a/src/taco-cli/cli/remoteBuild/remoteBuildClientHelper.ts
+++ b/src/taco-cli/cli/remoteBuild/remoteBuildClientHelper.ts
@@ -266,7 +266,7 @@ class RemoteBuildClientHelper {
         var newChangeTime: { [file: string]: number } = {};
         var isIncremental: boolean = false;
         try {
-            var json: { [file: string]: number } = JSON.parse(<any> fs.readFileSync(changeTimeFile));
+            var json: { [file: string]: number } = JSON.parse(fs.readFileSync(changeTimeFile, "utf8"));
             Object.keys(json).forEach(function (file: string): void {
                 lastChangeTime[file] = json[file];
             });

--- a/src/taco-cli/cli/utils/projectHelper.ts
+++ b/src/taco-cli/cli/utils/projectHelper.ts
@@ -154,7 +154,7 @@ class ProjectHelper {
             }
 
             if (fs.existsSync(tacoJsonFilePath)) {
-                tacoJson = JSON.parse(<any> fs.readFileSync(tacoJsonFilePath));
+                tacoJson = JSON.parse(fs.readFileSync(tacoJsonFilePath, "utf8"));
                 ProjectHelper.cachedProjectFilePath = tacoJsonFilePath;
             } else {
                 return projectInfo;

--- a/src/taco-cli/cli/utils/settings.ts
+++ b/src/taco-cli/cli/utils/settings.ts
@@ -44,7 +44,7 @@ class Settings {
         }
 
         try {
-            Settings.settings = JSON.parse(<any> fs.readFileSync(Settings.settingsFile));
+            Settings.settings = JSON.parse(fs.readFileSync(Settings.settingsFile, "utf8"));
             return Q(Settings.settings);
         } catch (e) {
             if (e.code === "ENOENT") {

--- a/src/taco-remote-lib/common/builder.ts
+++ b/src/taco-remote-lib/common/builder.ts
@@ -169,7 +169,7 @@ class Builder {
         var fetchJsonPath: string = path.join(remotePluginsPath, "fetch.json");
         if (fs.existsSync(fetchJsonPath)) {
             try {
-                fetchJson = JSON.parse(<any> fs.readFileSync(fetchJsonPath));
+                fetchJson = JSON.parse(fs.readFileSync(fetchJsonPath, "utf8"));
             } catch (e) {
                 // fetch.json is malformed; act as though no plugins are installed
                 // If it turns out we do need variables from the fetch.json, then cordova will throw an error

--- a/src/taco-utils/tacoPackageLoader.ts
+++ b/src/taco-utils/tacoPackageLoader.ts
@@ -124,7 +124,7 @@ module TacoUtility {
                 })
                 .then(function (): Q.Promise<string> {
                     var packageJsonFilePath = path.join(request.targetPath, "package.json");
-                    var packageJson = JSON.parse(<any> fs.readFileSync(packageJsonFilePath));
+                    var packageJson = JSON.parse(fs.readFileSync(packageJsonFilePath, "utf8"));
 
                     if (packageJson.bin && packageJson.bin[commandName]) {
                         var commandFilePath = path.join(request.targetPath, "..", ".bin", commandName);
@@ -325,7 +325,7 @@ module TacoUtility {
         private static createTacoPackageInstallRequest(packageKey: string, dependencyConfigPath: string, logLevel: InstallLogLevel): IPackageInstallRequest {
             if (fs.existsSync(dependencyConfigPath)) {
                 try {
-                    var dependencyLookup: any = JSON.parse(<any> fs.readFileSync(dependencyConfigPath));
+                    var dependencyLookup: any = JSON.parse(fs.readFileSync(dependencyConfigPath, "utf8"));
                     var packageEntry: IDynamicDependencyEntry = dependencyLookup[packageKey];
                     if (packageEntry) {
                         // if a local path is specified use that otherwise fallback to packageName@packageVersion


### PR DESCRIPTION
JSON.parse has the string type even though it accepts any object, so people will be forced to convert things to strings explicitly.