### PR TITLE
Combine external event name using "/" instead of "."

### DIFF
--- a/src/taco-utils/telemetryHelper.ts
+++ b/src/taco-utils/telemetryHelper.ts
@@ -263,7 +263,7 @@ module TacoUtility {
                     var telemetryProperties: ICommandTelemetryProperties = {};
                     TelemetryHelper.addTelemetryProperties(telemetryProperties, baseProps);
                     TelemetryHelper.addTelemetryProperties(telemetryProperties, props);
-                    var name = componentName + "." + event;
+                    var name = componentName + "/" + event;
                     if (error) {
                         if (errorHandler) {
                             error = errorHandler(error);


### PR DESCRIPTION
I meant to include this change with my earlier PR.

For consistency with other event name (like those generated by dependency installer), this combines the external event name using "/" instead of "." (so for `taco simulate`, for example, we end up with event names like `TACO/simulate/exec` instead of `TACO/simulate.exec`.