### PR TITLE
Fixes `CordovaWrapper.getGlobalCordovaVersion()` return value.

### DIFF
--- a/src/taco-cli/cli/utils/cordovaWrapper.ts
+++ b/src/taco-cli/cli/utils/cordovaWrapper.ts
@@ -158,7 +158,7 @@ class CordovaWrapper {
 
     public static getGlobalCordovaVersion(): Q.Promise<string> {
         return CordovaWrapper.cli(["-v"], true).then(function (output: string): string {
-            return output.split("\n")[0];
+            return output.split("\n")[0].split(" ")[0];
         });
     }
 


### PR DESCRIPTION
This method uses `cordova -v` to get the current Cordova version. That command returns the version in the following format:

    5.3.3 (cordova-lib@5.3.3)

The existing logic wasn't stripping off the bit in brackets. As a result, calls to `semver` methods (such as `semver.gte()` in `CordovaWrapper.requirements()`) could throw an exception.