### PR TITLE
Allowing user configuration of app launching timeout

### DIFF
--- a/src/taco-remote-lib/ios/ios.ts
+++ b/src/taco-remote-lib/ios/ios.ts
@@ -37,6 +37,7 @@ class IOSAgent implements ITargetPlatform {
     private webDebugProxyDevicePort: number;
     private webDebugProxyPortMin: number;
     private webDebugProxyPortMax: number;
+    private appLaunchStepTimeout: number;
 
     /**
      * Initialize iOS specific information from the configuration.
@@ -48,6 +49,8 @@ class IOSAgent implements ITargetPlatform {
         this.webDebugProxyDevicePort = config.get("webDebugProxyDevicePort") || 9221;
         this.webDebugProxyPortMin = config.get("webDebugProxyPortMin") || 9222;
         this.webDebugProxyPortMax = config.get("webDebugProxyPortMax") || 9322;
+
+        this.appLaunchStepTimeout = config.get("appLaunchStepTimeout") || 10000;
 
         if (utils.ArgsHelper.argToBool(config.get("allowsEmulate"))) {
             process.env["PATH"] = path.resolve(__dirname, path.join("..", "node_modules", ".bin")) + ":" + process.env["PATH"];
@@ -77,10 +80,11 @@ class IOSAgent implements ITargetPlatform {
         }
 
         var proxyPort: number = this.nativeDebugProxyPort;
+        var appLaunchStepTimeout = this.appLaunchStepTimeout;
         var cfg: utils.CordovaConfig = utils.CordovaConfig.getCordovaConfig(buildInfo.appDir);
         iosAppRunner.startDebugProxy(proxyPort)
             .then(function (nativeProxyProcess: child_process.ChildProcess): Q.Promise<net.Socket> {
-            return iosAppRunner.startApp(cfg.id(), proxyPort);
+            return iosAppRunner.startApp(cfg.id(), proxyPort, appLaunchStepTimeout);
         }).then(function (success: net.Socket): void {
             res.status(200).send(buildInfo.localize(req, resources));
         }, function (failure: any): void {

--- a/src/taco-remote-lib/ios/iosAppRunnerHelper.ts
+++ b/src/taco-remote-lib/ios/iosAppRunnerHelper.ts
@@ -40,7 +40,7 @@ class IosAppRunnerHelper {
 
     // Attempt to start the app on the device, using the debug server proxy on a given port.
     // Returns a socket speaking remote gdb protocol with the debug server proxy.
-    public static startApp(packageId: string, proxyPort: number): Q.Promise<net.Socket> {
+    public static startApp(packageId: string, proxyPort: number, appLaunchStepTimeout: number): Q.Promise<net.Socket> {
         // When a user has many apps installed on their device, the response from ideviceinstaller may be large (500k or more)
         // This exceeds the maximum stdout size that exec allows, so we redirect to a temp file.
         return promiseExec("ideviceinstaller -l -o xml > /tmp/$$.ideviceinstaller && echo /tmp/$$.ideviceinstaller").spread<string>(function (stdout: string, stderr: string): string {
@@ -60,10 +60,10 @@ class IosAppRunnerHelper {
             }
 
             throw new Error("PackageNotInstalled");
-        }).then(function (path: string): Q.Promise<net.Socket> { return IosAppRunnerHelper.startAppViaDebugger(proxyPort, path); });
+        }).then(function (path: string): Q.Promise<net.Socket> { return IosAppRunnerHelper.startAppViaDebugger(proxyPort, path, appLaunchStepTimeout); });
     }
 
-    public static startAppViaDebugger(portNumber: number, packagePath: string): Q.Promise<net.Socket> {
+    public static startAppViaDebugger(portNumber: number, packagePath: string, appLaunchStepTimeout: number): Q.Promise<net.Socket> {
         var encodedPath: string = IosAppRunnerHelper.encodePath(packagePath);
 
         // We need to send 3 messages to the proxy, waiting for responses between each message:
@@ -137,13 +137,8 @@ class IosAppRunnerHelper {
             initState++;
             socket.write(cmd);
             setTimeout(function (): void {
-                if (initState === 1) {
-                    deferred1.reject("DeviceLaunchTimeout");
-                    deferred2.reject("DeviceLaunchTimeout");
-                    deferred3.reject("DeviceLaunchTimeout");
-                    socket.end();
-                }
-            }, 5000);
+                deferred1.reject("DeviceLaunchTimeout");
+            }, appLaunchStepTimeout);
         });
 
         return deferred1.promise.then(function (sock: net.Socket): Q.Promise<net.Socket> {
@@ -152,12 +147,8 @@ class IosAppRunnerHelper {
             initState++;
             sock.write(cmd);
             setTimeout(function (): void {
-                if (initState === 2) {
-                    deferred2.reject("DeviceLaunchTimeout");
-                    deferred3.reject("DeviceLaunchTimeout");
-                    socket.end();
-                }
-            }, 5000);
+                deferred2.reject("DeviceLaunchTimeout");
+            }, appLaunchStepTimeout);
             return deferred2.promise;
         }).then(function (sock: net.Socket): Q.Promise<net.Socket> {
             // Continue execution; actually start the app running.
@@ -165,11 +156,8 @@ class IosAppRunnerHelper {
             initState++;
             sock.write(cmd);
             setTimeout(function (): void {
-                if (initState === 3) {
-                    deferred3.reject("DeviceLaunchTimeout");
-                    socket.end();
-                }
-            }, 5000);
+                deferred3.reject("DeviceLaunchTimeout");
+            }, appLaunchStepTimeout);
             return deferred3.promise;
         });
     }

--- a/src/taco-remote-lib/test/iosAppRunner.ts
+++ b/src/taco-remote-lib/test/iosAppRunner.ts
@@ -102,7 +102,7 @@ describe("Device functionality", function (): void {
             Logger.log("MockDebuggerProxy listening");
         });
 
-        Q.timeout(runner.startAppViaDebugger(port, appPath), 1000)
+        Q.timeout(runner.startAppViaDebugger(port, appPath, 5000), 1000)
             .done(function (): void {
             done();
         }, done);
@@ -179,7 +179,7 @@ describe("Device functionality", function (): void {
             Logger.log("MockDebuggerProxy listening");
         });
 
-        Q.timeout(runner.startAppViaDebugger(port, appPath), 1000).done(function (): void {
+        Q.timeout(runner.startAppViaDebugger(port, appPath, 5000), 1000).done(function (): void {
             done(new Error("Starting the app should have failed!"));
         }, function (err: any): void {
                 err.should.equal("UnableToLaunchApp");

--- a/src/taco-remote/lib/tacoRemoteConfig.ts
+++ b/src/taco-remote/lib/tacoRemoteConfig.ts
@@ -32,6 +32,8 @@ class TacoRemoteConfig implements RemoteBuild.IReadOnlyDictionary {
         webDebugProxyPortMin?: number;
         webDebugProxyPortMax?: number;
 
+        appLaunchStepTimeout?: number;
+
         [key: string]: any;
     };
 
@@ -47,7 +49,8 @@ class TacoRemoteConfig implements RemoteBuild.IReadOnlyDictionary {
             maxBuildsInQueue: 10,
             maxBuildsToKeep: 20,
             deleteBuildsOnShutdown: true,
-            allowsEmulate: true
+            allowsEmulate: true,
+            appLaunchStepTimeout: 10000
         };
         var hostDefaults: { [key: string]: any } = HostSpecifics.hostSpecifics.defaults(defaults);
         var self: TacoRemoteConfig = this;
@@ -60,7 +63,6 @@ class TacoRemoteConfig implements RemoteBuild.IReadOnlyDictionary {
 
     /**
      * @name allowsEmulate
-     * @LOCTAG TacoRemoteConfigAllowsEmulate
      */
     public get allowsEmulate(): boolean {
         return tacoUtils.ArgsHelper.argToBool(this.tacoRemoteConf.allowsEmulate);
@@ -68,7 +70,6 @@ class TacoRemoteConfig implements RemoteBuild.IReadOnlyDictionary {
 
     /**
      * @name deleteBuildsOnShutdown
-     * @LOCTAG TacoRemoteConfigDeleteBuildsOnShutdown
      */
     public get deleteBuildsOnShutdown(): boolean {
         return tacoUtils.ArgsHelper.argToBool(this.tacoRemoteConf.deleteBuildsOnShutdown);
@@ -76,7 +77,6 @@ class TacoRemoteConfig implements RemoteBuild.IReadOnlyDictionary {
 
     /**
      * @name maxBuildsInQueue
-     * @LOCTAG TacoRemoteConfigMaxBuildsInQueue
      */
     public get maxBuildsInQueue(): number {
         return this.tacoRemoteConf.maxBuildsInQueue;
@@ -84,7 +84,6 @@ class TacoRemoteConfig implements RemoteBuild.IReadOnlyDictionary {
 
     /**
      * @name maxBuildsToKeep
-     * @LOCTAG TacoRemoteConfigMaxBuildsToKeep
      */
     public get maxBuildsToKeep(): number {
         return this.tacoRemoteConf.maxBuildsToKeep;
@@ -92,7 +91,6 @@ class TacoRemoteConfig implements RemoteBuild.IReadOnlyDictionary {
 
     /**
      * @name nativeDebugProxyPort
-     * @LOCTAG TacoRemoteConfigNativeDebugProxyPort
      */
     public get nativeDebugProxyPort(): number {
         return this.tacoRemoteConf.nativeDebugProxyPort;
@@ -100,7 +98,6 @@ class TacoRemoteConfig implements RemoteBuild.IReadOnlyDictionary {
 
     /**
      * @name webDebugProxyDevicePort
-     * @LOCTAG TacoRemoteConfigWebDebugProxyDevicePort
      */
     public get webDebugProxyDevicePort(): number {
         return this.tacoRemoteConf.webDebugProxyDevicePort;
@@ -108,7 +105,6 @@ class TacoRemoteConfig implements RemoteBuild.IReadOnlyDictionary {
 
     /**
      * @name webDebugProxyPortMin
-     * @LOCTAG TacoRemoteConfigWebDebugProxyPortMin
      */
     public get webDebugProxyPortMin(): number {
         return this.tacoRemoteConf.webDebugProxyPortMin;
@@ -116,10 +112,13 @@ class TacoRemoteConfig implements RemoteBuild.IReadOnlyDictionary {
 
     /**
      * @name webDebugProxyPortMax
-     * @LOCTAG TacoRemoteConfigWebDebugProxyPortMax
      */
     public get webDebugProxyPortMax(): number {
         return this.tacoRemoteConf.webDebugProxyPortMax;
+    }
+
+    public get appLaunchStepTimeout(): number {
+        return this.tacoRemoteConf.appLaunchStepTimeout;
     }
 
     // These three properties are inherited from the parent configuration; no need for separate documentation


### PR DESCRIPTION
It seems that the time taken to communicate with the device can vary significantly between mac hosts, so I've bumped the default timeout and also allowed the end-user to specify the timeout if they desire.