### PR TITLE
Fix remotebuild help crash and add tests

### DIFF
--- a/src/remotebuild/package.json
+++ b/src/remotebuild/package.json
@@ -44,7 +44,8 @@
         "mocha": "2.0.1",
         "mkdirp": "0.3.5",
         "should": "4.3.0",
-        "request": "2.36.0"
+        "request": "2.36.0",
+        "colors": "^1.0.3"
     },
     "scripts": {
         "test": "mocha"

--- a/src/remotebuild/package.json
+++ b/src/remotebuild/package.json
@@ -45,7 +45,8 @@
         "mkdirp": "0.3.5",
         "should": "4.3.0",
         "request": "2.36.0",
-        "colors": "^1.0.3"
+        "colors": "^1.0.3",
+        "taco-tests-utils": "file:../taco-tests-utils"
     },
     "scripts": {
         "test": "mocha"

--- a/src/remotebuild/test/help.ts
+++ b/src/remotebuild/test/help.ts
@@ -1,0 +1,253 @@
+﻿/**
+ *******************************************************
+ *                                                     *
+ *   Copyright (C) Microsoft. All rights reserved.     *
+ *                                                     *
+ *******************************************************
+ */
+
+/// <reference path="../../typings/mocha.d.ts"/>
+/// <reference path="../../typings/should.d.ts"/>
+/// <reference path="../../typings/nconf.d.ts" />
+/// <reference path="../../typings/tacoUtils.d.ts"/>
+/// <reference path="../../typings/tacoTestsUtils.d.ts"/>
+
+"use strict";
+
+/* tslint:disable:no-var-requires */
+// var require needed for should module to work correctly
+// Note not import: We don't want to refer to shouldModule, but we need the require to occur since it modifies the prototype of Object.
+var shouldModule: any = require("should");
+/* tslint:enable:no-var-requires */
+
+/* tslint:disable:no-var-requires */
+// Special case to allow using color package with index signature for style rules
+var colors: any = require("colors/safe");
+/* tslint:enable:no-var-requires */
+
+import nconf = require("nconf");
+import path = require("path");
+import Q = require("q");
+
+import tacoUtils = require("taco-utils");
+import Help = require("../lib/help");
+import cli = require("../lib/cli");
+import RemoteBuildConf = require("../lib/remoteBuildConf");
+import tacoTestsUtils = require("taco-tests-utils");
+
+import UtilHelper = tacoUtils.UtilHelper;
+import ms = tacoTestsUtils;
+
+import ICommandData = tacoUtils.Commands.ICommandData;
+
+function parseRemoteBuildConf(): RemoteBuildConf {
+    // Configuration preference: command line, then anything in a config file if specified by the --config arg, then some defaults for options not yet set
+    nconf.argv();
+    // Default to using TACO_HOME/RemoteBuild.config
+    // If that file doesn't exist, then this will be equivalent to nconf.use("memory") as long as we don't try to save it out
+    var configFile: string = nconf.get("config") || path.join(UtilHelper.tacoHome, "RemoteBuild.config");
+    nconf.file({ file: configFile });
+
+    return new RemoteBuildConf(nconf);
+}
+
+describe("help for remotebuild", function (): void {
+    var remotebuildConf = parseRemoteBuildConf();
+    var help: Help = new Help(remotebuildConf);
+
+    var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later
+    var memoryStdout: ms.MemoryStream;
+    var previous: boolean;
+
+    function helpRun(command: string): Q.Promise<any> {
+        var data: ICommandData = {
+            options: {},
+            original: [command],
+            remain: [command]
+        };
+
+        return help.run(data);
+    };
+
+    function testHelpForCommand(command: string, expectedLines: string[], done: MochaDone): void {
+        helpRun(command).done(() => {
+            var expected: string = expectedLines.join("\n");
+            var actual: string = colors.strip(memoryStdout.contentsAsText()); // The colors add extra characters
+            actual = actual.replace(/ (\.+) ?\n  +/gm, " $1 "); // We undo the word-wrapping
+            actual = actual.replace(/ +$/gm, ""); // Remove useless spaces at the end of a line
+            actual.should.be.equal(expected);
+            done();
+        }, done);
+    }
+
+    before(() => {
+        previous = process.env["TACO_UNIT_TEST"];
+        process.env["TACO_UNIT_TEST"] = true;
+    });
+
+    after(() => {
+        // We just need to reset the stdout just once, after all the tests have finished
+        process.stdout.write = stdoutWrite;
+        process.env["TACO_UNIT_TEST"] = previous;
+    });
+
+    beforeEach(() => {
+        memoryStdout = new ms.MemoryStream; // Each individual test gets a new and empty console
+        process.stdout.write = memoryStdout.writeAsFunction(); // We'll be printing into an "in-memory" console, so we can test the output
+    });
+
+    it("prints the help for remotebuild", function (done: MochaDone): void {
+        testHelpForCommand("", [
+            "CommandHelpUsageSynopsis",
+            "   remotebuild <COMMAND>",
+            "",
+            "CommandHelpTableTitle",
+            "   start ............... CommandStartDescription",
+            "   test ................ CommandTestDescription",
+            "   certificates ........ CommandGenerateDescription",
+            "   saveconfig .......... CommandSaveConfigDescription",
+            "   help ................ CommandHelpDescription",
+            "   version ............. CommandVersionDescription",
+            "",
+            "RemoteBuildModuleHelpText",
+            ""], done);
+    });
+
+    it("prints the help for remotebuild start", function (done: MochaDone): void {
+        testHelpForCommand("start", [
+            "",
+            "CommandStartDescription",
+            "",
+            "   remotebuild start [options]",
+            "",
+            "CommandHelpUsageOptions",
+            "      --serverDir [DIRECTORY] ............ RemoteBuildConfServerDir",
+            "      --port [PORT-NUM] .................. RemoteBuildConfPort",
+            "      --secure [true|false] .............. RemoteBuildConfSecure",
+            "      --lang [LANGUAGE] .................. RemoteBuildConfLang",
+            "      --pinTimeout [MINS] ................ RemoteBuildConfPinTimeout",
+            "      --certExpirationDays [NUM_DAYS] .... RemoteBuildConfCertExpirationDays",
+            "      --hostname [HOSTNAME] .............. RemoteBuildConfHostname",
+            "      --config [PATH] .................... RemoteBuildConfConfigFile",
+            "CommandHelpUsageExamples",
+            "   * RemoteBuildStartExample1",
+            "",
+            "        remotebuild",
+            "",
+            "   * RemoteBuildStartExample2",
+            "",
+            "        remotebuild --serverDir ~/other-builds --port 4000 --secure false",
+            "",
+            "CommandHelpUsageNotes",
+            "   1. RemoteBuildNotes1",
+            "",
+            "   2. RemoteBuildNotes2",
+            "",
+            "",
+            "RemoteBuildModuleHelpText",
+            ""], done);
+    });
+
+    it("prints the help for remotebuild test", function (done: MochaDone): void {
+        testHelpForCommand("test", [
+            "",
+            "CommandTestDescription",
+            "",
+            "   remotebuild test [options]",
+            "",
+            "CommandHelpUsageOptions",
+            "      --device ........................... CommandTestDevice",
+            "      --serverDir [DIRECTORY] ............ RemoteBuildConfServerDir",
+            "      --port [PORT_NUM] .................. RemoteBuildConfPort",
+            "      --secure [true|false] .............. RemoteBuildConfSecure",
+            "      --lang [LANGUAGE] .................. RemoteBuildConfLang",
+            "      --pinTimeout [MINS] ................ RemoteBuildConfPinTimeout",
+            "      --certExpirationDays [NUM_DAYS] .... RemoteBuildConfCertExpirationDays",
+            "      --hostname [HOSTNAME] .............. RemoteBuildConfHostname",
+            "      --config [PATH] .................... RemoteBuildConfConfigFile",
+            "CommandHelpUsageExamples",
+            "   * RemoteBuildTestExample1",
+            "",
+            "        remotebuild test",
+            "",
+            "   * RemoteBuildTestExample2",
+            "",
+            "        remotebuild test --device --config config.json",
+            "",
+            "CommandHelpUsageNotes",
+            "   1. RemoteBuildNotes1",
+            "",
+            "   2. RemoteBuildNotes2",
+            "",
+            "",
+            "RemoteBuildModuleHelpText",
+            ""], done);
+    });
+
+    it("prints the help for remotebuild certificates", function (done: MochaDone): void {
+        testHelpForCommand("certificates", [
+            "",
+            "CommandGenerateDescription",
+            "",
+            "   remotebuild certificates [COMMAND] [Options]",
+            "",
+            "CommandHelpUsageParameters",
+            "   generate .............................. CommandGenerateDescription",
+            "   reset ................................. CommandResetDescription",
+            "CommandHelpUsageOptions",
+            "      --serverDir [DIRECTORY] ............ RemoteBuildConfServerDir",
+            "      --port [PORT-NUM] .................. RemoteBuildConfPort",
+            "      --lang [LANGUAGE] .................. RemoteBuildConfLang",
+            "      --certExpirationDays [NUM_DAYS] .... RemoteBuildConfCertExpirationDays",
+            "      --hostname [HOSTNAME] .............. RemoteBuildConfHostname",
+            "      --config [PATH] .................... RemoteBuildConfConfigFile",
+            "CommandHelpUsageExamples",
+            "   * GenerateClientCertExample1",
+            "",
+            "        remotebuild certificates generate --certExpirationDays 365",
+            "",
+            "   * ResetServerCertExample1",
+            "",
+            "        remotebuild certificates reset --certExpirationDays 365",
+            "",
+            "CommandHelpUsageNotes",
+            "   1. RemoteBuildNotes1",
+            "",
+            "   2. RemoteBuildNotes2",
+            "",
+            "",
+            "RemoteBuildModuleHelpText",
+            ""], done);
+    });
+
+    it("prints the help for remotebuild saveconfig", function (done: MochaDone): void {
+        testHelpForCommand("saveconfig", [
+            "",
+            "CommandSaveConfigDescription",
+            "",
+            "   remotebuild saveconfig [Options]",
+            "",
+            "CommandHelpUsageOptions",
+            "      --serverDir [DIRECTORY] ............ RemoteBuildConfServerDir",
+            "      --port [PORT-NUM] .................. RemoteBuildConfPort",
+            "      --lang [LANGUAGE] .................. RemoteBuildConfLang",
+            "      --certExpirationDays [NUM_DAYS] .... RemoteBuildConfCertExpirationDays",
+            "      --hostname [HOSTNAME] .............. RemoteBuildConfHostname",
+            "      --config [PATH] .................... RemoteBuildConfConfigFile",
+            "",
+            "RemoteBuildModuleHelpText",
+            ""], done);
+    });
+
+    it("prints the help for remotebuild version", function (done: MochaDone): void {
+        testHelpForCommand("version", [
+            "",
+            "CommandVersionDescription",
+            "",
+            "   remotebuild version",
+            "",
+            "",
+            "RemoteBuildModuleHelpText",
+            ""], done);
+    });
+});

--- a/src/remotebuild/test/help.ts
+++ b/src/remotebuild/test/help.ts
@@ -26,7 +26,6 @@ var colors: any = require("colors/safe");
 /* tslint:enable:no-var-requires */
 
 import nconf = require("nconf");
-import path = require("path");
 import Q = require("q");
 
 import tacoUtils = require("taco-utils");
@@ -36,27 +35,17 @@ import RemoteBuildConf = require("../lib/remoteBuildConf");
 import tacoTestsUtils = require("taco-tests-utils");
 
 import UtilHelper = tacoUtils.UtilHelper;
-import ms = tacoTestsUtils;
+import MemoryStream = tacoTestsUtils.MemoryStream;
 
 import ICommandData = tacoUtils.Commands.ICommandData;
 
-function parseRemoteBuildConf(): RemoteBuildConf {
-    // Configuration preference: command line, then anything in a config file if specified by the --config arg, then some defaults for options not yet set
-    nconf.argv();
-    // Default to using TACO_HOME/RemoteBuild.config
-    // If that file doesn't exist, then this will be equivalent to nconf.use("memory") as long as we don't try to save it out
-    var configFile: string = nconf.get("config") || path.join(UtilHelper.tacoHome, "RemoteBuild.config");
-    nconf.file({ file: configFile });
-
-    return new RemoteBuildConf(nconf);
-}
-
 describe("help for remotebuild", function (): void {
-    var remotebuildConf = parseRemoteBuildConf();
+    nconf.use("memory");
+    var remotebuildConf: RemoteBuildConf = new RemoteBuildConf(nconf);
     var help: Help = new Help(remotebuildConf);
 
     var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later
-    var memoryStdout: ms.MemoryStream;
+    var memoryStdout: MemoryStream;
     var previous: boolean;
 
     function helpRun(command: string): Q.Promise<any> {
@@ -92,7 +81,7 @@ describe("help for remotebuild", function (): void {
     });
 
     beforeEach(() => {
-        memoryStdout = new ms.MemoryStream; // Each individual test gets a new and empty console
+        memoryStdout = new MemoryStream; // Each individual test gets a new and empty console
         process.stdout.write = memoryStdout.writeAsFunction(); // We'll be printing into an "in-memory" console, so we can test the output
     });
 
@@ -245,6 +234,42 @@ describe("help for remotebuild", function (): void {
             "CommandVersionDescription",
             "",
             "   remotebuild version",
+            "",
+            "",
+            "RemoteBuildModuleHelpText",
+            ""], done);
+    });
+    
+    it("prints the help for taco-remote module", function (done: MochaDone): void {
+        testHelpForCommand("taco-remote", [
+            "",
+            "TacoRemoteHelpDescription",
+            "CommandHelpUsageOptions",
+            "      allowsEmulate .............. TacoRemoteConfigAllowsEmulate",
+            "      deleteBuildsOnShutdown ..... TacoRemoteConfigDeleteBuildsOnShutdown",
+            "      maxBuildsInQueue ........... TacoRemoteConfigMaxBuildsInQueue",
+            "      maxBuildsToKeep ............ TacoRemoteConfigMaxBuildsToKeep",
+            "      nativeDebugProxyPort ....... TacoRemoteConfigNativeDebugProxyPort",
+            "      webDebugProxyDevicePort .... TacoRemoteConfigWebDebugProxyDevicePort",
+            "      webDebugProxyPortMin ....... TacoRemoteConfigWebDebugProxyPortMin",
+            "      webDebugProxyPortMax ....... TacoRemoteConfigWebDebugProxyPortMax",
+            "CommandHelpUsageExamples",
+            "   * TacoRemoteHelpExample",
+            "",
+            "      {",
+            "         \"port\": 3002,",
+            "         \"modules\": {",
+            "            \"taco-remote\": {",
+            "               \"mountPath\": \"cordova\",",
+            "               \"maxBuildsToKeep\": 0,",
+            "               \"webDebugProxyDevicePort\": 4321,",
+            "               \"deleteBuildsOnShutdown\": true",
+            "            }",
+            "         }",
+            "      }",
+            "",
+            "CommandHelpUsageNotes",
+            "   * TacoRemoteHelpNotes",
             "",
             "",
             "RemoteBuildModuleHelpText",

--- a/src/remotebuild/test/help.ts
+++ b/src/remotebuild/test/help.ts
@@ -239,7 +239,7 @@ describe("help for remotebuild", function (): void {
             "RemoteBuildModuleHelpText",
             ""], done);
     });
-    
+
     it("prints the help for taco-remote module", function (done: MochaDone): void {
         testHelpForCommand("taco-remote", [
             "",

--- a/src/taco-cli/test/checkForNewerVersion.ts
+++ b/src/taco-cli/test/checkForNewerVersion.ts
@@ -10,6 +10,7 @@
 /// <reference path="../../typings/should.d.ts" />
 /// <reference path="../../typings/del.d.ts" />
 /// <reference path="../../typings/node.d.ts"/>
+/// <reference path="../../typings/tacoTestsUtils.d.ts"/>
 
 "use strict";
 
@@ -28,11 +29,12 @@ import Settings = require ("../cli/utils/settings");
 import RemoteMock = require ("./utils/remoteMock");
 import TacoUtility = require ("taco-utils");
 import CheckForNewerVersion = require ("../cli/utils/checkForNewerVersion");
-import ms = require ("./utils/memoryStream");
+import tacoTestsUtils = require ("taco-tests-utils");
 import http = require ("http");
 import ServerMock = require ("./utils/serverMock");
 
 import utils = TacoUtility.UtilHelper;
+import MemoryStream = tacoTestsUtils.MemoryStream;
 
 enum MessageExpectation {
     WillBeShown,
@@ -47,7 +49,7 @@ describe("Check for newer version", function (): void {
     // because of function overloading assigning "(buffer: string, cb?: Function) => boolean" as the type for
     // stdoutWrite just doesn't work
     var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later
-    var memoryStdout: ms.MemoryStream;
+    var memoryStdout: MemoryStream;
 
     var expectedRequestAndResponse: { expectedUrl: string; statusCode: number; head: any; response: any; waitForPayload?: boolean, responseDelay?: number };
 
@@ -68,7 +70,7 @@ describe("Check for newer version", function (): void {
     });
 
     beforeEach(() => {
-        memoryStdout = new ms.MemoryStream; // Each individual test gets a new and empty console
+        memoryStdout = new MemoryStream; // Each individual test gets a new and empty console
         process.stdout.write = memoryStdout.writeAsFunction(); // We'll be printing into an "in-memory" console, so we can test the output
 
         // These contents were copied from http://registry.npmjs.org/remotebuild/latest and then renamed to what should be a taco-cli response

--- a/src/taco-cli/test/create.ts
+++ b/src/taco-cli/test/create.ts
@@ -12,6 +12,7 @@
 /// <reference path="../../typings/wrench.d.ts"/>
 /// <reference path="../../typings/tacoUtils.d.ts"/>
 /// <reference path="../../typings/tacoKits.d.ts"/>
+/// <reference path="../../typings/tacoTestsUtils.d.ts"/>
 
 "use strict";
 
@@ -43,12 +44,13 @@ import tacoUtils = require ("taco-utils");
 import tacoTestUtils = require ("taco-tests-utils");
 
 import TemplateManager = require ("../cli/utils/templateManager");
-import ms = require ("./utils/memoryStream");
+import tacoTestsUtils = require ("taco-tests-utils");
 
 import IKeyValuePair = tacoTestUtils.IKeyValuePair;
 import TacoKitsErrorCodes = tacoKits.TacoErrorCode;
 import TacoUtilsErrorCodes = tacoUtils.TacoErrorCode;
 import utils = tacoUtils.UtilHelper;
+import MemoryStream = tacoTestsUtils.MemoryStream;
 
 import CommandHelper = require ("./utils/commandHelper");
 import ICommand = tacoUtils.Commands.ICommand;
@@ -443,10 +445,10 @@ describe("taco create", function (): void {
         // because of function overloading assigning "(buffer: string, cb?: Function) => boolean" as the type for
         // stdoutWrite just doesn't work
         var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later
-        var memoryStdout: ms.MemoryStream;
+        var memoryStdout: MemoryStream;
 
         beforeEach(() => {
-            memoryStdout = new ms.MemoryStream; // Each individual test gets a new and empty console
+            memoryStdout = new MemoryStream; // Each individual test gets a new and empty console
             process.stdout.write = memoryStdout.writeAsFunction(); // We'll be printing into an "in-memory" console, so we can test the output
         });
 

--- a/src/taco-cli/test/help.ts
+++ b/src/taco-cli/test/help.ts
@@ -9,6 +9,7 @@
 /// <reference path="../../typings/mocha.d.ts"/>
 /// <reference path="../../typings/should.d.ts"/>
 /// <reference path="../../typings/tacoUtils.d.ts"/>
+/// <reference path="../../typings/tacoTestsUtils.d.ts"/>
 
 "use strict";
 
@@ -25,18 +26,19 @@ var colors: any = require("colors/safe");
 
 import tacoUtils = require ("taco-utils");
 import Help = require ("../cli/help");
-import ms = require ("./utils/memoryStream");
+import tacoTestsUtils = require ("taco-tests-utils");
 
 import ICommandData = tacoUtils.Commands.ICommandData;
 import CommandHelper = require ("./utils/commandHelper");
 import ICommand = tacoUtils.Commands.ICommand;
+import MemoryStream = tacoTestsUtils.MemoryStream;
 
 describe("help for a command", function (): void {
     var help: ICommand = CommandHelper.getCommand("help");
     // because of function overloading assigning "(buffer: string, cb?: Function) => boolean" as the type for
     // stdoutWrite just doesn't work
     var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later
-    var memoryStdout: ms.MemoryStream;
+    var memoryStdout: MemoryStream;
     var previous: boolean;
 
     function helpRun(command: string): Q.Promise<any> {
@@ -72,7 +74,7 @@ describe("help for a command", function (): void {
     });
 
     beforeEach(() => {
-        memoryStdout = new ms.MemoryStream; // Each individual test gets a new and empty console
+        memoryStdout = new MemoryStream; // Each individual test gets a new and empty console
         process.stdout.write = memoryStdout.writeAsFunction(); // We'll be printing into an "in-memory" console, so we can test the output
     });
 

--- a/src/taco-cli/test/platformPlugin.ts
+++ b/src/taco-cli/test/platformPlugin.ts
@@ -10,6 +10,8 @@
 /// <reference path="../../typings/should.d.ts" />
 /// <reference path="../../typings/cordovaExtensions.d.ts" />
 /// <reference path="../../typings/del.d.ts" />
+/// <reference path="../../typings/tacoTestsUtils.d.ts"/>
+
 "use strict";
 
 /* tslint:disable:no-var-requires */
@@ -35,13 +37,14 @@ import kitHelper = require ("../cli/utils/kitHelper");
 import resources = require ("../resources/resourceManager");
 import TacoUtility = require ("taco-utils");
 import TacoTestUtility = require ("taco-tests-utils");
-import ms = require("./utils/memoryStream");
+import tacoTestsUtils = require("taco-tests-utils");
 import CommandHelper = require ("./utils/commandHelper");
 
 import ICommand = tacoUtility.Commands.ICommand;
 import IKeyValuePair = TacoTestUtility.IKeyValuePair;
 import TestProjectHelper = TacoTestUtility.ProjectHelper;
 import utils = TacoUtility.UtilHelper;
+import MemoryStream = tacoTestsUtils.MemoryStream;
 
 var platformCommand: ICommand = CommandHelper.getCommand("platform");
 var pluginCommand: ICommand = CommandHelper.getCommand("plugin");
@@ -439,7 +442,7 @@ describe("taco platform for kit", function(): void {
         // because of function overloading assigning "(buffer: string, cb?: Function) => boolean" as the type for
         // stdoutWrite just doesn't work
         var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later
-        var memoryStdout: ms.MemoryStream;
+        var memoryStdout: MemoryStream;
 
         beforeEach(function(done: MochaDone): void {
             this.timeout(60000); // Instaling the node packages during create can take a long time
@@ -447,7 +450,7 @@ describe("taco platform for kit", function(): void {
             // We create a taco project outside of the test
             Q.fcall(createCliProject, "5.0.0").done(() => {
                 // After the taco project is created, we initialize the console, so we won't get the creation messages in the console
-                memoryStdout = new ms.MemoryStream; // Each individual test gets a new and empty console
+                memoryStdout = new MemoryStream; // Each individual test gets a new and empty console
                 process.stdout.write = memoryStdout.writeAsFunction(); // We'll be printing into an "in-memory" console, so we can test the output
                 done();
             }, function(err: any): void {

--- a/src/taco-cli/test/remote.ts
+++ b/src/taco-cli/test/remote.ts
@@ -8,6 +8,8 @@
 /// <reference path="../../typings/mocha.d.ts" />
 /// <reference path="../../typings/node.d.ts" />
 /// <reference path="../../typings/should.d.ts" />
+/// <reference path="../../typings/tacoTestsUtils.d.ts"/>
+
 "use strict";
 
 /* tslint:disable:no-var-requires */
@@ -34,11 +36,12 @@ import RemoteMod = require ("../cli/remote");
 import RemoteMock = require ("./utils/remoteMock");
 import IRemoteServerSequence = require ("./utils/remoteServerSequence");
 import TacoUtility = require ("taco-utils");
-import ms = require ("./utils/memoryStream");
+import tacoTestsUtils = require ("taco-tests-utils");
 import CommandHelper = require ("./utils/commandHelper");
 import ICommand = TacoUtility.Commands.ICommand;
 
 import utils = TacoUtility.UtilHelper;
+import MemoryStream = tacoTestsUtils.MemoryStream;
 
 var remote: ICommand = CommandHelper.getCommand("remote");
 
@@ -237,10 +240,10 @@ describe("taco remote", function(): void {
         // because of function overloading assigning "(buffer: string, cb?: Function) => boolean" as the type for
         // stdoutWrite just doesn't work
         var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later
-        var memoryStdout: ms.MemoryStream;
+        var memoryStdout: MemoryStream;
 
         beforeEach(() => {
-            memoryStdout = new ms.MemoryStream; // Each individual test gets a new and empty console
+            memoryStdout = new MemoryStream; // Each individual test gets a new and empty console
             process.stdout.write = memoryStdout.writeAsFunction(); // We'll be printing into an "in-memory" console, so we can test the output
         });
 

--- a/src/taco-cli/test/templates.ts
+++ b/src/taco-cli/test/templates.ts
@@ -10,6 +10,7 @@
 /// <reference path="../../typings/should.d.ts"/>
 /// <reference path="../../typings/tacoUtils.d.ts"/>
 /// <reference path="../../typings/tacoKits.d.ts"/>
+/// <reference path="../../typings/tacoTestsUtils.d.ts"/>
 
 "use strict";
 
@@ -26,9 +27,10 @@ var colors: any = require("colors/safe");
 
 import tacoUtils = require ("taco-utils");
 import Templates = require ("../cli/templates");
-import ms = require ("./utils/memoryStream");
+import tacoTestsUtils = require ("taco-tests-utils");
 
 import commands = tacoUtils.Commands.ICommandData;
+import MemoryStream = tacoTestsUtils.MemoryStream;
 
 describe("templates", function (): void {
     this.timeout(20000);
@@ -62,10 +64,10 @@ describe("templates", function (): void {
         // because of function overloading assigning "(buffer: string, cb?: Function) => boolean" as the type for
         // stdoutWrite just doesn't work
         var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later
-        var memoryStdout: ms.MemoryStream;
+        var memoryStdout: MemoryStream;
 
         beforeEach(() => {
-            memoryStdout = new ms.MemoryStream; // Each individual test gets a new and empty console
+            memoryStdout = new MemoryStream; // Each individual test gets a new and empty console
             process.stdout.write = memoryStdout.writeAsFunction(); // We'll be printing into an "in-memory" console, so we can test the output
         });
 

--- a/src/taco-tests-utils/memoryStream.ts
+++ b/src/taco-tests-utils/memoryStream.ts
@@ -6,7 +6,7 @@
 ﻿ *******************************************************
 ﻿ */
 
-/// <reference path="../../../typings/node.d.ts"/>
+/// <reference path="../typings/node.d.ts"/>
 
 "use strict";
 

--- a/src/taco-tests-utils/tacoTestsUtils.ts
+++ b/src/taco-tests-utils/tacoTestsUtils.ts
@@ -10,6 +10,7 @@
 import nodeFakes = require("./nodeFakes");
 import projectHelper = require("./projectHelper");
 import telemetryFakes = require("./telemetryFakes");
+import memoryStream = require("./memoryStream");
 
 module TacoTestsUtils {
     /* tslint:disable:variable-name */
@@ -18,6 +19,7 @@ module TacoTestsUtils {
     export var NodeFakes: typeof nodeFakes.NodeFakes = nodeFakes.NodeFakes;
     export var TelemetryFakes: typeof telemetryFakes.TelemetryFakes = telemetryFakes.TelemetryFakes;
     export var ProjectHelper: typeof projectHelper.ProjectHelper = projectHelper.ProjectHelper;
+    export var MemoryStream: typeof memoryStream.MemoryStream = memoryStream.MemoryStream;
     /* tslint:enable:variable-name */
 }
 

--- a/src/taco-utils/helpCommandBase.ts
+++ b/src/taco-utils/helpCommandBase.ts
@@ -114,7 +114,7 @@ module TacoUtility {
          * @param {string} command - TACO command being inquired
          */
         private printCommandUsage(command: string): void {
-            if (this.commandsFactory.aliases[command]) {
+            if (this.commandsFactory.aliases && this.commandsFactory.aliases[command]) {
                 command = this.commandsFactory.aliases[command];
             }
 
@@ -263,7 +263,7 @@ module TacoUtility {
          * @param {string} id - command to query
          */
         private commandExists(command: string): boolean {
-            return command in this.commandsFactory.listings || command in this.commandsFactory.aliases;
+            return command in this.commandsFactory.listings || (this.commandsFactory.aliases && command in this.commandsFactory.aliases);
         }
     }
 }

--- a/src/typings/memoryStream.d.ts
+++ b/src/typings/memoryStream.d.ts
@@ -1,0 +1,20 @@
+/**
+ *******************************************************
+ *                                                     *
+ *   Copyright (C) Microsoft. All rights reserved.     *
+ *                                                     *
+ *******************************************************
+ */
+
+/// <reference path="../typings/node.d.ts" />
+
+declare module TacoTestsUtils {
+    class MemoryStream extends NodeJSStream.Writable {
+		public _write(data: Buffer, encoding: string, callback: Function): void;
+		public _write(data: string, encoding: string, callback: Function): void;
+		public _write(data: any, encoding: string, callback: Function): void;
+		
+        public contentsAsText(): string;
+        public writeAsFunction(): { (data: any, second: any, callback?: any): boolean };
+    }
+}

--- a/src/typings/tacoTestsUtils.d.ts
+++ b/src/typings/tacoTestsUtils.d.ts
@@ -9,6 +9,7 @@
 /// <reference path="../typings/nodeFakes.d.ts" />
 /// <reference path="../typings/telemetryFakes.d.ts" />
 /// <reference path="../typings/projectHelper.d.ts" />
+/// <reference path="../typings/memoryStream.d.ts" />
 
 // To add more classes, make sure that they define themselves in the TacoTestsUtils namespace,
 // include a reference to the d.ts file that is generated (as above), and make sure


### PR DESCRIPTION
## Summary
Added null guards to the HelpCommandBase when we resolve aliases. Added tests for remotebuild help, and some test refactoring.

## Changes
* Added null checks to HelpCommandBase class when resolving aliases.
* Added tests for remotebuild help commands.
* Moved the MemoryStream class to the tacoTestUtils module.
* Added typings for MemoryStream.
* Updated existing tests that used MemoryStream
