### PR TITLE
Ensuring that test settings are isolated to the remotebuild help tests.

### DIFF
--- a/src/remotebuild/test/help.ts
+++ b/src/remotebuild/test/help.ts
@@ -40,10 +40,7 @@ import MemoryStream = tacoTestsUtils.MemoryStream;
 import ICommandData = tacoUtils.Commands.ICommandData;
 
 describe("help for remotebuild", function (): void {
-    nconf.use("memory");
-    var remotebuildConf: RemoteBuildConf = new RemoteBuildConf(nconf);
-    var help: Help = new Help(remotebuildConf);
-
+    var help: Help;
     var stdoutWrite = process.stdout.write; // We save the original implementation, so we can restore it later
     var memoryStdout: MemoryStream;
     var previous: boolean;
@@ -72,12 +69,21 @@ describe("help for remotebuild", function (): void {
     before(() => {
         previous = process.env["TACO_UNIT_TEST"];
         process.env["TACO_UNIT_TEST"] = true;
+
+        nconf.overrides({});
+        nconf.defaults({});
+        nconf.use("memory");
+
+        var remotebuildConf: RemoteBuildConf = new RemoteBuildConf(nconf);
+        help = new Help(remotebuildConf);
     });
 
     after(() => {
         // We just need to reset the stdout just once, after all the tests have finished
         process.stdout.write = stdoutWrite;
-        process.env["TACO_UNIT_TEST"] = previous;
+        delete process.env["TACO_UNIT_TEST"];
+
+        nconf.reset();
     });
 
     beforeEach(() => {


### PR DESCRIPTION
## Summary
Ensuring that the remotebuild help tests correctly configure and reset their preconditions. The nconf package is global-ish and can effect other tests. Also the process environment variable needs to be deleted and not set to a value.

## Changes
* Moved nconf configuration to before()
* Added nconf reset to after()
* Deleting TACO_UNIT_TEST process environment variable.