### PR TITLE
Move old AndroidSdkInstaller tests that were related to the package installer, to the AndroidPackagesInstaller tests, and fixed them

### DIFF
--- a/src/taco-dependency-installer/test/androidPackagesInstaller.ts
+++ b/src/taco-dependency-installer/test/androidPackagesInstaller.ts
@@ -26,6 +26,7 @@ var shouldModule = require("should");
 
 import installerProtocol = require("../elevatedInstallerProtocol");
 import FakeLogger = require("./fakeLogger");
+import InstallerBase = require("../installers/installerBase");
 import _ = require("lodash");
 import mockery = require("mockery");
 import mockFs = require("mock-fs");
@@ -39,7 +40,7 @@ import nodeFakes = tacoTestsUtils.NodeFakes;
 
 type TelemetryEvent = TacoUtility.ICommandTelemetryProperties;
 
-describe("AndroidSdkInstaller telemetry", () => {
+describe("AndroidPackagesInstaller telemetry", () => {
     // Parameters for AndroidSdkInstaller
     var steps: DependencyInstallerInterfaces.IStepsDeclaration;
     var installerInfo: DependencyInstallerInterfaces.IInstallerData = {
@@ -56,8 +57,28 @@ describe("AndroidSdkInstaller telemetry", () => {
     var mockPath: typeof path;
     var fakeTelemetryHelper: TacoTestsUtils.TelemetryFakes.Helper;
     var fakeProcess: nodeFakes.Process;
-    var androidSdkInstallerClass: any;
+    var androidPackagesInstallerClass: any;
     var childProcessModule: nodeFakes.ChildProcessModule;
+
+    var androidSdkPackages = `----------
+    id: 3 or "sys-img-x86-addon-google_apis-google-23"
+    Type: SystemImage
+    Desc: System Image x86 with Google APIs.
+        Revision 8
+    Requires SDK Platform Android API 23
+    ----------
+    id: 4 or "extra-android-m2repository"
+    Type: Extra
+    Desc: Android Support Repository, revision 24
+    By Android
+    Local Maven repository for Support Libraries
+           Install path: extras\android\m2repository
+    ----------
+    id: 5 or "extra-android-support"
+    Type: Extra
+    Desc: Android Support Library, revision 23.1
+    By Android
+    Install path: extras\android\support`;
 
     before(() => {
         // We tell mockery to replace "require()" with our own custom mock objects
@@ -88,8 +109,8 @@ describe("AndroidSdkInstaller telemetry", () => {
         mockPath = <typeof path> _.extend({}, path);
         mockery.registerMock("path", mockPath); // installerUtils uses path.delimiter, and it breaks the Windows tests on mac if not
 
-        // We require the AndroidSdkInstaller file, which will use all the mocked dependencies
-        androidSdkInstallerClass = require("../installers/androidSdkInstaller");
+        // We require the AndroidPackagesInstaller file, which will use all the mocked dependencies
+        androidPackagesInstallerClass = require("../installers/androidPackagesInstaller");
     });
 
     after(() => {
@@ -107,10 +128,9 @@ describe("AndroidSdkInstaller telemetry", () => {
 
     function telemetryGeneratedShouldBe(expectedTelemetry: TacoUtility.ICommandTelemetryProperties[],
         expectedMessagePattern: RegExp, done: MochaDone): Q.Promise<any> {
-        var androidSdkInstaller = new androidSdkInstallerClass(installerInfo, softwareVersion, installTo,
-            new FakeLogger(), steps);
+        var androidPackagesInstaller = new androidPackagesInstallerClass(installerInfo, softwareVersion, installTo, new FakeLogger(), steps);
 
-        return androidSdkInstaller.run()
+        return androidPackagesInstaller.run()
             .then(() => Q.reject(new Error("Should have gotten a rejection in this test")), (error: Error) => {
                 return fakeTelemetryHelper.getAllSentEvents().then((allSentEvents: TelemetryEvent[]) => {
                     // We check the message first, because some coding defects can make the tests end in unexpected states
@@ -122,90 +142,122 @@ describe("AndroidSdkInstaller telemetry", () => {
             }).done(done, done);
     }
 
-    describe("updateVariablesDarwin", () => {
-        it("generates telemetry if there is an error on the update command", (done: MochaDone) => {
-            fakeProcess.fakeMacOS();
-            steps.updateVariables = true; // We only test this step on this test
+    describe("in windows", () => {
+        beforeEach(() => {
+            fakeProcess.fakeWindows();
+            mockPath.delimiter = ";"; // Installer utils uses this, and the path logic breaks in Mac if we don't mock it
 
-            var expectedTelemetry: TacoUtility.ICommandTelemetryProperties[] = [
-                {
-                    "initialStep.time": { isPii: false, value: "2000" },
-                    step: { isPii: false, value: "initialStep" }
-                },
-                {
-                    "error.description": { isPii: false, value: "ErrorOnChildProcess on updateVariablesDarwin" },
-                    lastStepExecuted: { isPii: false, value: "updateVariables" },
-                    step: { isPii: false, value: "updateVariables" },
-                    time: { isPii: false, value: "3000" },
-                    "updateVariables.time": { isPii: false, value: "2000" }
-                }
-            ];
-
-            return telemetryGeneratedShouldBe(expectedTelemetry, /Error while executing/, done);
-        });
-    });
-
-    describe("installation", () => {
-        it("generates telemetry error if there is no install location", (done: MochaDone) => {
-            fakeProcess.fakeMacOS();
             steps.install = true; // We only test this step on this test
-            installTo = ""; // We don't have an install location
 
-            var expectedTelemetry: TacoUtility.ICommandTelemetryProperties[] = [
-                {
-                    "initialStep.time": { isPii: false, value: "2000" },
-                    step: { isPii: false, value: "initialStep" }
-                },
-                {
-                    "error.description": { isPii: false, value: "NeedInstallDestination on installDefault" },
-                    "install.time": { isPii: false, value: "2000" },
-                    lastStepExecuted: { isPii: false, value: "install" },
-                    step: { isPii: false, value: "install" },
-                    time: { isPii: false, value: "3000" }
-                }];
+            // Set ANDROID_HOME so updateVariables won't try to re-set it
+            installTo = "C:\\Program Files (x86)\\Android"; // We don't have an install location
+            var androidHomePath = fakeProcess.env.ANDROID_HOME = mockPath.join(installTo, "android-sdk-windows");
 
-            return telemetryGeneratedShouldBe(expectedTelemetry, /NeedInstallDestination/, done);
-        });
-    });
+            // Set android paths in the PATH so we won't have to add them
+            var platformToolsPath = mockPath.join(androidHomePath, "platform-tools");
+            var androidToolsPath = mockPath.join(androidHomePath, "tools");
+            fakeProcess.env.PATH = platformToolsPath + mockPath.delimiter + androidToolsPath;
 
-    describe("post-installation in mac", () => {
-        it("generates telemetry error if we can't give executable permissions to the android executable", (done: MochaDone) => {
-            fakeProcess.fakeMacOS();
+            // Create a fake project.properties file
+            var projectPropertiesPath = path.join("platforms", "android", "project.properties");
 
-            steps.postInstall = true; // We only test this step on this test
-            steps.updateVariables = true; // We need this step because post-install uses this.androidHomeValue populated in this step
+            // Fake resources file
+            var baseDirName = path.dirname(__dirname);
+            var resourcesPath = path.join(baseDirName, "resources", "en", "resources.json");
 
-            // child_process.exec will succeed while setting the path, and fail while giving permissions
-            childProcessModule.fakeUsingCommandToDetermineResult((command: string) => /export PATH=/.test(command),
-                (command: string) => /chmod a\+x/.test(command));
-
-            var filePath = path.join(fakeProcess.env.HOME, ".bash_profile");
             var files: mockFs.Config = {};
-            files[filePath] = "";
+            files[projectPropertiesPath] = "target=sys-img-x86-addon-google_apis-google-23";
+            files[resourcesPath] = "{}";
             mockFs(files);
+        });
+
+        it("reports telemetry when getAvailableAndroidPackages fails emiting error", (done: MochaDone) => {
+            var spawnErrorMessage = "The command is not recognized by the system";
+            childProcessModule.mockSpawn.setDefault(function (callback: Function): void {
+                /* Warning: The "this" in the next line is the one passed by mockSpawn library. For that
+                   to work this context needs to be a JavaScript lambda function. Do not convert this to
+                   an arrow function, or this will break because of the change in semantics. */
+                this.emit("error", new Error(spawnErrorMessage)); // invokes childProcess.on('error')
+                setTimeout(() => callback(0), 0); // Then the child process ends with an arbitrary error code of 8
+            });
 
             var expectedTelemetry: TacoUtility.ICommandTelemetryProperties[] = [
                 {
                     "initialStep.time": { isPii: false, value: "2000" },
                     step: { isPii: false, value: "initialStep" }
-                },
-                {
-                    step: { isPii: false, value: "updateVariables" },
-                    "updateVariables.time": { isPii: false, value: "1000" }
                 },
                 {
                     "error.description": {
                         isPii: false,
-                        value: "ErrorOnChildProcess on addExecutePermission"
+                        value: "ErrorOnChildProcess on getAvailableAndroidPackages"
                     },
-                    lastStepExecuted: { isPii: false, value: "postInstall" },
-                    "postInstall.time": { isPii: false, value: "2000" },
-                    step: { isPii: false, value: "postInstall" },
-                    time: { isPii: false, value: "5000" }
+                    "install.time": { isPii: false, value: "2000" },
+                    lastStepExecuted: { isPii: false, value: "install" },
+                    step: { isPii: false, value: "install" },
+                    time: { isPii: false, value: "3000" }
                 }
             ];
 
-            return telemetryGeneratedShouldBe(expectedTelemetry, /Error while executing/g, done);
+            return telemetryGeneratedShouldBe(expectedTelemetry, new RegExp(spawnErrorMessage), done);
+        });
+
+        it("reports telemetry when getAvailableAndroidPackages fails with error code", (done: MochaDone) => {
+            childProcessModule.mockSpawn.setDefault(function (callback: Function): void {
+                setTimeout(() => callback(8), 0); // Then the child process ends with an arbitrary error code of 8
+            });
+
+            var expectedTelemetry: TacoUtility.ICommandTelemetryProperties[] = [
+                {
+                    "initialStep.time": { isPii: false, value: "2000" },
+                    step: { isPii: false, value: "initialStep" }
+                },
+                {
+                    "error.code": { isPii: false, value: "8" },
+                    "error.description": {
+                        isPii: false,
+                        value: "ErrorOnExitOfChildProcess on getAvailableAndroidPackages"
+                    },
+                    "error.message": { isPii: true, value: "" },
+                    "install.time": { isPii: false, value: "2000" },
+                    lastStepExecuted: { isPii: false, value: "install" },
+                    step: { isPii: false, value: "install" },
+                    time: { isPii: false, value: "3000" }
+                }
+            ];
+
+            return telemetryGeneratedShouldBe(expectedTelemetry, /^$/, done); // We don't have an error message
+        });
+
+        it("reports telemetry when killing adb is not recognized as a command", (done: MochaDone) => {
+            // First two calls to list and install the android packages will succeed
+            childProcessModule.mockSpawn.sequence.add(childProcessModule.mockSpawn.simple(/*exitCode*/ 0, /*stdout*/ androidSdkPackages, /*stderr*/ ""));
+            childProcessModule.mockSpawn.sequence.add(childProcessModule.mockSpawn.simple(/*exitCode*/ 0, /*stdout*/ androidSdkPackages, /*stderr*/ ""));
+
+            // Third call to kill adb will fail
+            var spawnErrorMessage = "The kill adb command is not recognized by the system";
+            childProcessModule.mockSpawn.sequence.add(function (callback: Function): void {
+                /* Warning: The "this" in the next line is the one passed by mockSpawn library. For that
+                   to work this context needs to be a JavaScript lambda function. Do not convert this to
+                   an arrow function, or this will break because of the change in semantics. */
+                this.emit("error", new Error(spawnErrorMessage)); // invokes childProcess.on('error')
+                setTimeout(() => callback(0), 0); // Then the child process ends with an arbitrary error code of 0
+            });
+
+            var expectedTelemetry: TacoUtility.ICommandTelemetryProperties[] = [
+                {
+                    "initialStep.time": { isPii: false, value: "2000" },
+                    step: { isPii: false, value: "initialStep" }
+                },
+                {
+                    "error.description": { isPii: false, value: "ErrorOnKillingAdb in killAdb" },
+                    "install.time": { isPii: false, value: "2000" },
+                    lastStepExecuted: { isPii: false, value: "install" },
+                    step: { isPii: false, value: "install" },
+                    time: { isPii: false, value: "3000" }
+                }
+            ];
+
+            return telemetryGeneratedShouldBe(expectedTelemetry, new RegExp(spawnErrorMessage), done);
         });
     });
 });


### PR DESCRIPTION
- Moved skiped AndroidSdkInstaller tests to a new file androidPackagesInstaller.ts
- Fixed the tests
- Refactored some AndroidPackagesInstaller code

Manual tests:
  * Run install-reqs with no Android SDK installed
  * Run install-reqs when only the target is missing
  * Run install-reqs when android.bat doesn't exit
  * Run install-reqs when android.bat exits with an error code
  * Run install-reqs when adb.exe doesn't exist (I removed it after it was installed)