### PR TITLE
Updating taco-remote-lib to cope with cordova 5.4.0

### DIFF
--- a/src/taco-cli/test/utils/mockCordova.ts
+++ b/src/taco-cli/test/utils/mockCordova.ts
@@ -89,7 +89,7 @@ module MockCordova {
         }
     }
 
-    export class MockCordovaRaw510 implements Cordova.ICordovaRaw510 {
+    export class MockCordovaRaw510 implements Cordova.ICordovaRaw510T<Cordova.ICordovaRawOptions> {
         public config: any = {};
         public help: any = {};
 

--- a/src/taco-remote-lib/common/builder.ts
+++ b/src/taco-remote-lib/common/builder.ts
@@ -30,7 +30,7 @@ import UtilHelper = utils.UtilHelper;
 
 class Builder {
     protected currentBuild: BuildInfo;
-    protected cordova: Cordova.ICordova;
+    protected cordova: Cordova.ICordova540;
 
     private static change_directory(appDir: string): void {
         process.chdir(appDir);
@@ -40,7 +40,7 @@ class Builder {
         return;
     }
 
-    constructor(currentBuild: BuildInfo, cordova: Cordova.ICordova) {
+    constructor(currentBuild: BuildInfo, cordova: Cordova.ICordova540) {
         this.currentBuild = currentBuild;
         this.cordova = cordova;
 
@@ -237,8 +237,19 @@ class Builder {
 
     private compile_platform(): Q.Promise<any> {
         Logger.log("cordova compile " + this.currentBuild.buildPlatform);
-        var configuration: string = (this.currentBuild.configuration === "debug") ? "--debug" : "--release";
-        var opts: string [] = (this.currentBuild.options.length > 0) ? [this.currentBuild.options, configuration] : [configuration];
+        //var opts: string [] = (this.currentBuild.options.length > 0) ? [this.currentBuild.options, configuration] : [configuration];
+        var opts: Cordova.ICordova540BuildOptions = {};
+        if (this.currentBuild.configuration === "debug") {
+            opts.debug = true;
+        } else {
+            opts.release = true;
+        }
+        if (this.currentBuild.options.indexOf("--device") !== -1) {
+            opts.device = true;
+        } else {
+            opts.emulator = true;
+        }
+        opts.argv = this.currentBuild.options;
         return this.cordova.raw.compile({ platforms: [this.currentBuild.buildPlatform], options: opts });
     }
 }

--- a/src/taco-remote-lib/ios/iosBuild.ts
+++ b/src/taco-remote-lib/ios/iosBuild.ts
@@ -46,7 +46,7 @@ process.on("message", function (buildRequest: { buildInfo: BuildInfo; language: 
     var cordovaVersion: string = buildInfo["vcordova"];
     buildInfo.updateStatus(BuildInfo.BUILDING, "AcquiringCordova");
     process.send(buildInfo);
-    TacoPackageLoader.lazyRequire<Cordova.ICordova>("cordova", "cordova@" + cordovaVersion, buildInfo.logLevel).done(function (pkg: Cordova.ICordova): void {
+    TacoPackageLoader.lazyRequire<Cordova.ICordova540>("cordova", "cordova@" + cordovaVersion, buildInfo.logLevel).done(function (pkg: Cordova.ICordova540): void {
         var iosBuilder: IOSBuilder = new IOSBuilder(buildInfo, pkg);
 
         iosBuilder.build().done(function (resultBuildInfo: BuildInfo): void {
@@ -62,7 +62,7 @@ class IOSBuilder extends Builder {
     public static running: boolean = false;
     private cfg: CordovaConfig;
 
-    constructor(currentBuild: BuildInfo, cordova: Cordova.ICordova) {
+    constructor(currentBuild: BuildInfo, cordova: Cordova.ICordova540) {
         super(currentBuild, cordova);
 
         this.cfg = CordovaConfig.getCordovaConfig(currentBuild.appDir);

--- a/src/taco-remote-lib/package.json
+++ b/src/taco-remote-lib/package.json
@@ -1,7 +1,7 @@
 {
     "name": "taco-remote-lib",
     "description": "Cordova-specific implementation of taco-remote's build functionality",
-    "version": "1.2.1-dev",
+    "version": "2.0.0-dev",
     "author": {
       "name": "Microsoft Corporation",
       "email": "vscordovatools-admin@microsoft.com"

--- a/src/taco-remote-lib/test/iosAppRunner.ts
+++ b/src/taco-remote-lib/test/iosAppRunner.ts
@@ -32,10 +32,9 @@ interface IMockDebuggerProxy extends net.Server {
 // Tests for lib/darwin/darwinAppRunner.js functionality
 describe("Device functionality", function (): void {
     // Check that when the debugger behaves nicely, we do as well
+    var port: number = 12345;
     it("should complete the startup sequence when the debugger is well behaved", function (done: MochaDone): void {
-        var port: number = 12345;
         var appPath: string = "/private/var/mobile/Applications/042F57CA-9717-4655-8349-532093FFCF44/BlankCordovaApp1.app";
-
         var encodedAppPath: string = "2F707269766174652F7661722F6D6F62696C652F4170706C69636174696F6E732F30343246353743412D393731372D343635352D383334392D3533323039334646434634342F426C616E6B436F72646F7661417070312E617070";
         encodedAppPath.should.equal(runner.encodePath(appPath));
 
@@ -102,15 +101,11 @@ describe("Device functionality", function (): void {
             Logger.log("MockDebuggerProxy listening");
         });
 
-        Q.timeout(runner.startAppViaDebugger(port, appPath, 5000), 1000)
-            .done(function (): void {
-            done();
-        }, done);
+        Q.timeout(runner.startAppViaDebugger(port, appPath, 5000), 1000).done(() => done(), done);
     });
 
     // Check that when the debugger reports an error, we notice it
     it("should report an error if the debugger fails for some reason", function (done: MochaDone): void {
-        var port: number = 12345;
         var appPath: string = "/private/var/mobile/Applications/042F57CA-9717-4655-8349-532093FFCF44/BlankCordovaApp1.app";
 
         var encodedAppPath: string = "2F707269766174652F7661722F6D6F62696C652F4170706C69636174696F6E732F30343246353743412D393731372D343635352D383334392D3533323039334646434634342F426C616E6B436F72646F7661417070312E617070";
@@ -179,11 +174,10 @@ describe("Device functionality", function (): void {
             Logger.log("MockDebuggerProxy listening");
         });
 
-        Q.timeout(runner.startAppViaDebugger(port, appPath, 5000), 1000).done(function (): void {
-            done(new Error("Starting the app should have failed!"));
+        Q.timeout(runner.startAppViaDebugger(port, appPath, 5000), 1000).then(function (): void {
+            throw new Error("Starting the app should have failed!");
         }, function (err: any): void {
-                err.should.equal("UnableToLaunchApp");
-                done();
-            });
+            err.should.equal("UnableToLaunchApp");
+        }).done(() => done(), done);
     });
 });

--- a/src/taco-remote-multiplexer/dynamicDependencies.json
+++ b/src/taco-remote-multiplexer/dynamicDependencies.json
@@ -1,8 +1,12 @@
 ﻿{
   "latestTacoRemoteLib": {
     "packageName": "taco-remote-lib",
-    "packageId": "taco-remote-lib@1.2.1",
-    "dev":  true
+    "packageId": "taco-remote-lib@2.0.0",
+    "dev": true
+  },
+  "preCordova540TacoRemoteLib": {
+    "packageName": "taco-remote-lib",
+    "packageId": "taco-remote-lib@1.2.0"
   },
 
   "samplePackageInNpm": {

--- a/src/taco-remote-multiplexer/tacoRemoteMultiplexer.ts
+++ b/src/taco-remote-multiplexer/tacoRemoteMultiplexer.ts
@@ -17,8 +17,11 @@ class TacoRemoteMultiplexer implements TacoRemoteMultiplexer.ITacoRemoteMultiple
     public getPackageSpecForQuery(query: TacoRemoteMultiplexer.IPropertyBag): TacoRemoteMultiplexer.IPackageSpec {
         // Note: As new scenarios are added, place them at the top of the function and not the bottom.
         // This will ensure that if previous scenarios worked, they will continue to do so, and newer cases take precedence over older ones.
-        if (semver.valid(query["vcordova"]) && semver.satisfies(query["vcordova"], ">=3.0.0 <6.0.0")) {
-            return <TacoRemoteMultiplexer.IPackageSpec> { packageKey: "latestTacoRemoteLib", dependencyConfigPath: dependencyConfigPath };
+        if (semver.valid(query["vcordova"]) && semver.gte(query["vcordova"], "5.4.0")) {
+            return <TacoRemoteMultiplexer.IPackageSpec>{ packageKey: "latestTacoRemoteLib", dependencyConfigPath: dependencyConfigPath };
+        }
+        if (semver.valid(query["vcordova"]) && semver.satisfies(query["vcordova"], ">=3.0.0 <5.4.0")) {
+            return <TacoRemoteMultiplexer.IPackageSpec>{ packageKey: "preCordova540TacoRemoteLib", dependencyConfigPath: dependencyConfigPath };
         }
 
         return <TacoRemoteMultiplexer.IPackageSpec> { packageKey: "latestTacoRemoteLib", dependencyConfigPath: dependencyConfigPath };

--- a/src/taco-remote/test/build.ts
+++ b/src/taco-remote/test/build.ts
@@ -25,6 +25,7 @@ describe("taco-remote", function(): void {
     var modMountPoint: string = "Test";
 
     before(function(mocha: MochaDone): void {
+        this.timeout(10000); // the cleanup of TACO_HOME can take a while sometimes.
         process.env["TACO_UNIT_TEST"] = true;
         process.env["TACO_HOME"] = serverDir;
         rimraf.sync(UtilHelper.tacoHome);

--- a/src/typings/cordovaExtensions.d.ts
+++ b/src/typings/cordovaExtensions.d.ts
@@ -41,6 +41,26 @@ declare module Cordova {
         silent?: boolean;
         browserify?: boolean;
     }
+
+    export interface ICordova540BuildOptions {
+        debug?: boolean;
+        release?: boolean;
+        device?: boolean;
+        emulator?: boolean;
+        target?: string;
+        nobuild?: boolean;
+        archs?: string[];
+        buildconfig?: string;
+        argv?: string[];
+    }
+
+    export interface ICordova540RawOptions {
+        platforms: string[];
+        options?: ICordova540BuildOptions;
+        verbose?: boolean;
+        silent?: boolean;
+        browserify?: boolean;
+    }
     
     export interface ICordovaLibMetadata {
         url?: string;
@@ -98,38 +118,47 @@ declare module Cordova {
         cli_variables?: IKeyValueStore<string>;
     }
 
-    export interface ICordovaRaw {
-        build(options: ICordovaRawOptions): Q.Promise<any>;
+    export interface ICordovaRawT<OptionType> {
+        build(options: OptionType): Q.Promise<any>;
         config: any;
-        compile(options: ICordovaRawOptions): Q.Promise<any>;
+        compile(options: OptionType): Q.Promise<any>;
         create(dir: string, id?: string, name?: string, cfg?: any): Q.Promise<any>;
-        emulate(options: ICordovaRawOptions): Q.Promise<any>;
+        emulate(options: OptionType): Q.Promise<any>;
         help: any;
         info(): Q.Promise<any[]>;
         platform(command: any, targets?: any, opts?: any): Q.Promise<any>;
         platforms(command: any, targets?: any, opts?: any): Q.Promise<any>;
         plugin(command: any, targets?: any, opts?: ICordovaPluginOptions): Q.Promise<any>;
         plugins(command: any, targets?: any, opts?: any): Q.Promise<any>;
-        prepare(options: ICordovaRawOptions): Q.Promise<any>;
+        prepare(options: OptionType): Q.Promise<any>;
         restore(target: any, args: any): Q.Promise<any>;
-        run(options: ICordovaRawOptions): Q.Promise<any>;
+        run(options: OptionType): Q.Promise<any>;
         save(target: any, opts?: any): Q.Promise<any>;
         serve(port: number): Q.Promise<NodeJSHttp.Server>;
-        targets(options: ICordovaRawOptions): Q.Promise<any>;
+        targets(options: OptionType): Q.Promise<any>;
     }
 
-    export interface ICordovaRaw510 extends ICordovaRaw {
+    export interface ICordovaRaw510T<T> extends ICordovaRawT<T> {
         requirements(platforms: string[]): Q.Promise<any>;
     }
 
-    export interface ICordova {
+
+    export interface ICordovaT<T> {
         on(event: string, ...args: any[]): void;
         off(event: string, ...args: any[]): void;
         emit(event: string, ...args: any[]): void;
         trigger(event: string, ...args: any[]): void;
         cli(args: string[]): void;
-        raw: ICordovaRaw;
+        raw: ICordovaRawT<T>;
     }
+
+    export interface ICordova510T<T> extends ICordovaT<T> {
+        raw: ICordovaRaw510T<T>;
+    }
+
+    export type ICordova = ICordovaT<ICordovaRawOptions>; // Pre-5.1.0 cordova
+    export type ICordova510 = ICordova510T<ICordovaRawOptions>; // >= 5.1.0 < 5.4.0 cordova
+    export type ICordova540 = ICordova510T<ICordova540RawOptions>; // Post-5.4.0 cordova
 
     export interface IFetchJson {
         [key: string]: {
@@ -137,16 +166,14 @@ declare module Cordova {
         }
     }
 
-    export interface ICordova510 extends ICordova {
-        raw: ICordovaRaw510;
-    }
+
 
     export function on(event: string, ...args: any[]): void;
     export function off(event: string, ...args: any[]): void;
     export function emit(event: string, ...args: any[]): void;
     export function trigger(event: string, ...args: any[]): void;
     export function cli(args: string[]): void;
-    export var raw: ICordovaRaw;
+    export var raw: ICordovaRawT<ICordovaRawOptions | ICordova540RawOptions>;
 }
 
 declare module "cordova" {


### PR DESCRIPTION
Cordova 5.4.0 uses a new option type to pass arguments, and this change adapts to that. taco-remote-multiplexer now inspects the cordova version, and selects between a new version and the previous version depending on which cordova is targeted.