### PR TITLE
Fixing some formatting issues with TacoError

### DIFF
--- a/src/taco-cli/cli/tacoErrorHelper.ts
+++ b/src/taco-cli/cli/tacoErrorHelper.ts
@@ -7,15 +7,15 @@ import TacoErrorCode = require ("./tacoErrorCodes");
 
 class TacoErrorHelper {
     public static get(tacoErrorCode: TacoErrorCode, ...optionalArgs: any[]): tacoUtils.TacoError {
-        return tacoUtils.TacoError.getError(TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, optionalArgs);
+        return tacoUtils.TacoError.getError(TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, ...optionalArgs);
     }
 
     public static getWarning(errorToken: string, ...optionalArgs: any[]): tacoUtils.TacoError {
-        return tacoUtils.TacoError.getWarning(errorToken, resourceManager, optionalArgs);
+        return tacoUtils.TacoError.getWarning(errorToken, resourceManager, ...optionalArgs);
     }
 
     public static wrap(tacoErrorCode: TacoErrorCode, innerError: Error, ...optionalArgs: any[]): tacoUtils.TacoError {
-        return tacoUtils.TacoError.wrapError(innerError, TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, optionalArgs);
+        return tacoUtils.TacoError.wrapError(innerError, TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, ...optionalArgs);
     }
 }
 

--- a/src/taco-dependency-installer/tacoErrorHelper.ts
+++ b/src/taco-dependency-installer/tacoErrorHelper.ts
@@ -18,11 +18,11 @@ import TacoErrorCode = tacoErrorCode.TacoErrorCode;
 
 class TacoErrorHelper {
     public static get(tacoErrorCode: TacoErrorCode, ...optionalArgs: any[]): tacoUtils.TacoError {
-        return tacoUtils.TacoError.getError(TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, optionalArgs);
+        return tacoUtils.TacoError.getError(TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, ...optionalArgs);
     }
 
     public static wrap(tacoErrorCode: TacoErrorCode, innerError: Error, ...optionalArgs: any[]): tacoUtils.TacoError {
-        return tacoUtils.TacoError.wrapError(innerError, TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, optionalArgs);
+        return tacoUtils.TacoError.wrapError(innerError, TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, ...optionalArgs);
     }
 }
 

--- a/src/taco-kits/tacoErrorHelper.ts
+++ b/src/taco-kits/tacoErrorHelper.ts
@@ -9,11 +9,11 @@ import TacoErrorCode = tacoErrorCode.TacoErrorCode;
 
 class TacoErrorHelper {
     public static get(tacoErrorCode: TacoErrorCode, ...optionalArgs: any[]): tacoUtils.TacoError {
-        return tacoUtils.TacoError.getError(TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, tacoResources, optionalArgs);
+        return tacoUtils.TacoError.getError(TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, tacoResources, ...optionalArgs);
     }
 
     public static wrap(tacoErrorCode: TacoErrorCode, innerError: Error, ...optionalArgs: any[]): tacoUtils.TacoError {
-        return tacoUtils.TacoError.wrapError(innerError, TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, tacoResources, optionalArgs);
+        return tacoUtils.TacoError.wrapError(innerError, TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, tacoResources, ...optionalArgs);
     }
 }
 

--- a/src/taco-utils/tacoError.ts
+++ b/src/taco-utils/tacoError.ts
@@ -49,7 +49,7 @@ module TacoUtility {
             return true;
         }
 
-        public static getWarning(errorToken: string, resources: ResourceManager, ...optionalArgs: any[]): TacoError {
+        public static getWarning(errorToken: string, resources: ResourceManager, ...optionalArgs: string[]): TacoError {
             var message: string = TacoError.getMessageString(errorToken, resources, optionalArgs);
 
             // We do not use an error code for Warnings
@@ -59,25 +59,19 @@ module TacoUtility {
             return warning;
         }
 
-        public static getError(errorToken: string, errorCode: number, resources: ResourceManager, ...optionalArgs: any[]): TacoError {
-            var args: string[] = [];
-            if (optionalArgs.length > 0) {
-                args = ArgsHelper.getOptionalArgsArrayFromFunctionCall(arguments, 3);
-            }
-
-            return TacoError.wrapError(null, errorToken, errorCode, resources, args);
+        public static getError(errorToken: string, errorCode: number, resources: ResourceManager, ...optionalArgs: string[]): TacoError {
+            return TacoError.wrapError(null, errorToken, errorCode, resources, ...optionalArgs);
         }
 
-        public static wrapError(innerError: Error, errorToken: string, errorCode: number, resources: ResourceManager, ...optionalArgs: any[]): TacoError {
+        public static wrapError(innerError: Error, errorToken: string, errorCode: number, resources: ResourceManager, ...optionalArgs: string[]): TacoError {
             var message: string = TacoError.getMessageString(errorToken, resources, optionalArgs);
             return new TacoError(errorCode, message, innerError);
         }
 
-        public static getMessageString(errorToken: string, resources: ResourceManager, ...optionalArgs: any[]): string {
+        private static getMessageString(errorToken: string, resources: ResourceManager, args: string[]): string {
             var message: string = null;
-            if (optionalArgs.length > 0) {
+            if (args.length > 0) {
                 assert(errorToken, "We should have an error token if we intend to use args");
-                var args: string[] = ArgsHelper.getOptionalArgsArrayFromFunctionCall(arguments, 4);
                 if (errorToken) {
                     message = resources.getString(errorToken, args);
                 }

--- a/src/taco-utils/tacoErrorHelper.ts
+++ b/src/taco-utils/tacoErrorHelper.ts
@@ -9,11 +9,11 @@ import TacoErrorCode = tacoErrorCodes.TacoErrorCode;
 
 class TacoErrorHelper {
     public static get(tacoErrorCode: TacoErrorCode, ...optionalArgs: any[]): tacoUtils.TacoError {
-        return tacoUtils.TacoError.getError(TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, optionalArgs);
+        return tacoUtils.TacoError.getError(TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, ...optionalArgs);
     }
 
     public static wrap(tacoErrorCode: TacoErrorCode, innerError: Error, ...optionalArgs: any[]): tacoUtils.TacoError {
-        return tacoUtils.TacoError.wrapError(innerError, TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, optionalArgs);
+        return tacoUtils.TacoError.wrapError(innerError, TacoErrorCode[tacoErrorCode], <number> tacoErrorCode, resourceManager, ...optionalArgs);
     }
 }
 

--- a/src/taco-utils/test/tacoErrors.ts
+++ b/src/taco-utils/test/tacoErrors.ts
@@ -11,13 +11,21 @@
 "use strict";
 
 import path = require ("path");
-import shouldModule = require("should");
+import should = require("should");
 
 import resources = require ("../resources/resourceManager");
+import resourceManager = require ("../resourceManager");
+import tacoError = require("../tacoError");
 
 describe("taco Errors in taco-utils", function (): void {
     it("Verify taco Errors in taco-utils", function (): void {
         verifyTacoErrors(path.join(__dirname, "../tacoErrorCodes.js"), resources, 100, 999);
+    });
+
+    it("should replace placeholders correctly", function (): void {
+        var testResourceManager = new resourceManager.ResourceManager(path.join(__dirname, "resources"), "en");
+        var testError = tacoError.TacoError.getError("MessageWithArgs", 10, testResourceManager, "foo", "bar", "baz");
+        should(testError.message).equal(testResourceManager.getString("MessageWithArgs", "foo", "bar", "baz"));
     });
 });
 
@@ -39,11 +47,11 @@ describe("taco Errors in taco-utils", function (): void {
                     errorCode + " and " + errorCodes[numericErrorCode] + " have been assigned same error code");
 
                 // Verify that error code is within range
-                shouldModule(numericErrorCode).greaterThan(minErrorCode, "error code " + errorCode + " is less than min: " + minErrorCode);
-                shouldModule(numericErrorCode).lessThan(maxErrorCode, "error code " + errorCode + " is more than max: " + maxErrorCode);
+                should(numericErrorCode).greaterThan(minErrorCode, "error code " + errorCode + " is less than min: " + minErrorCode);
+                should(numericErrorCode).lessThan(maxErrorCode, "error code " + errorCode + " is more than max: " + maxErrorCode);
 
                 // Verify we have a resource string for the error code
-                shouldModule(resources.getString(errorCode)).not.equal(null, "no resources found for error code " + errorCode);
+                should(resources.getString(errorCode)).not.equal(null, "no resources found for error code " + errorCode);
             }
         });
     }

--- a/src/typings/tacoError.d.ts
+++ b/src/typings/tacoError.d.ts
@@ -13,9 +13,9 @@ declare module TacoUtility {
 
         constructor(errorCode: number, message: string, category?: string, innerError?: Error);
 
-        public static getError(errorToken: string, errorCode: number, resources: ResourceManager, ...optionalArgs: any[]): TacoError;
-        public static getWarning(errorToken: string, resources: ResourceManager, ...optionalArgs: any[]): TacoError;
-        public static wrapError(innerError: Error, errorToken: string, errorCode: number, resources: ResourceManager, ...optionalArgs: any[]): TacoError;
+        public static getError(errorToken: string, errorCode: number, resources: ResourceManager, ...optionalArgs: string[]): TacoError;
+        public static getWarning(errorToken: string, resources: ResourceManager, ...optionalArgs: string[]): TacoError;
+        public static wrapError(innerError: Error, errorToken: string, errorCode: number, resources: ResourceManager, ...optionalArgs: string[]): TacoError;
         public toString(): string;
     }
 }


### PR DESCRIPTION
There was a flaw in how TacoError extracted arguments meaning that errors often had incorrect information in them. This change fixes that error, corrects how variadic arguments are passed through, and adds in a test case to make sure that we catch future regressions.