### PR TITLE
Changing taco-remote-lib to store the handle to idevicedebugserverpro…

### DIFF
--- a/src/taco-remote-lib/ios/ios.ts
+++ b/src/taco-remote-lib/ios/ios.ts
@@ -33,7 +33,6 @@ import UtilHelper = utils.UtilHelper;
 
 class IOSAgent implements ITargetPlatform {
     private nativeDebugProxyPort: number;
-    private webProxyInstance: child_process.ChildProcess = null;
     private webDebugProxyDevicePort: number;
     private webDebugProxyPortMin: number;
     private webDebugProxyPortMax: number;
@@ -230,14 +229,18 @@ class IOSAgent implements ITargetPlatform {
     }
 
     public debugBuild(buildInfo: utils.BuildInfo, req: Express.Request, res: Express.Response): void {
-        if (this.webProxyInstance) {
-            this.webProxyInstance.kill();
-            this.webProxyInstance = null;
+        if (!global.tacoRemoteLib) {
+            global.tacoRemoteLib = {};
+        }
+
+        if (global.tacoRemoteLib.webProxyInstance) {
+            global.tacoRemoteLib.webProxyInstance.kill();
+            global.tacoRemoteLib.webProxyInstance = null;
         }
 
         var portRange: string = util.format("null:%d,:%d-%d", this.webDebugProxyDevicePort, this.webDebugProxyPortMin, this.webDebugProxyPortMax);
         try {
-            this.webProxyInstance = child_process.spawn("ios_webkit_debug_proxy", ["-c", portRange]);
+            global.tacoRemoteLib.webProxyInstance = child_process.spawn("ios_webkit_debug_proxy", ["-c", portRange]);
         } catch (e) {
             res.status(404).send(resources.getStringForLanguage(req, "UnableToDebug"));
             return;


### PR DESCRIPTION
…xy in a global variable to be explicitly shared between instances

idevicedebugserverproxy (more specifically the port that we configure it to use) is essentially a shared resource, and this change makes that explicit. If we end up running multiple instances of taco-remote-lib consecutively in order to handle multiple incompatible versions of Cordova, this change makes sure that the packages will check in a known, shared location to access the proxy. An identical change is needed on top of taco-remote-lib@1.2.0 to allow it to cooperate as well.