### PR TITLE
Fix concurrent taco remote lib packages

### DIFF
--- a/src/taco-remote-lib/ios/ios.ts
+++ b/src/taco-remote-lib/ios/ios.ts
@@ -24,6 +24,7 @@ import Packer = require ("zip-stream");
 
 import iosAppRunner = require ("./iosAppRunnerHelper");
 import resources = require ("../resources/resourceManager");
+import sharedState = require ("./sharedState");
 import utils = require ("taco-utils");
 
 import BuildInfo = utils.BuildInfo;
@@ -229,26 +230,28 @@ class IOSAgent implements ITargetPlatform {
     }
 
     public debugBuild(buildInfo: utils.BuildInfo, req: Express.Request, res: Express.Response): void {
-        if (!global.tacoRemoteLib) {
-            global.tacoRemoteLib = {};
-        }
-
-        if (global.tacoRemoteLib.webProxyInstance) {
-            global.tacoRemoteLib.webProxyInstance.kill();
-            global.tacoRemoteLib.webProxyInstance = null;
+        if (sharedState.webProxyInstance) {
+            sharedState.webProxyInstance.kill();
+            sharedState.webProxyInstance = null;
         }
 
         var portRange: string = util.format("null:%d,:%d-%d", this.webDebugProxyDevicePort, this.webDebugProxyPortMin, this.webDebugProxyPortMax);
-        try {
-            global.tacoRemoteLib.webProxyInstance = child_process.spawn("ios_webkit_debug_proxy", ["-c", portRange]);
-        } catch (e) {
-            res.status(404).send(resources.getStringForLanguage(req, "UnableToDebug"));
-            return;
-        }
 
-        buildInfo["webDebugProxyPort"] = this.webDebugProxyDevicePort;
-        buildInfo.updateStatus(utils.BuildInfo.DEBUGGING, "DebugSuccess");
-        res.status(200).send(buildInfo.localize(req, resources));
+        var deferred = Q.defer();
+        sharedState.webProxyInstance = child_process.spawn("ios_webkit_debug_proxy", ["-c", portRange]);
+        sharedState.webProxyInstance.on("error", function (err: Error) {
+            deferred.reject(new Error(resources.getStringForLanguage(req, "UnableToDebug")));
+        });
+        // Allow some time for the spawned process to error out
+        Q.delay(250).then(() => deferred.resolve({}));
+
+        deferred.promise.then(() => {
+            buildInfo["webDebugProxyPort"] = this.webDebugProxyDevicePort;
+            buildInfo.updateStatus(utils.BuildInfo.DEBUGGING, "DebugSuccess");
+            res.status(200).send(buildInfo.localize(req, resources));
+        }, (err: Error) => {
+            res.status(500).send(err.message);
+        });
     }
 
     public createBuildProcess(): child_process.ChildProcess {

--- a/src/taco-remote-lib/ios/ios.ts
+++ b/src/taco-remote-lib/ios/ios.ts
@@ -33,7 +33,6 @@ import UtilHelper = utils.UtilHelper;
 
 class IOSAgent implements ITargetPlatform {
     private nativeDebugProxyPort: number;
-    private webProxyInstance: child_process.ChildProcess = null;
     private webDebugProxyDevicePort: number;
     private webDebugProxyPortMin: number;
     private webDebugProxyPortMax: number;
@@ -230,14 +229,18 @@ class IOSAgent implements ITargetPlatform {
     }
 
     public debugBuild(buildInfo: utils.BuildInfo, req: Express.Request, res: Express.Response): void {
-        if (this.webProxyInstance) {
-            this.webProxyInstance.kill();
-            this.webProxyInstance = null;
+        if (!global.tacoRemoteLib) {
+            global.tacoRemoteLib = {};
+        }
+
+        if (global.tacoRemoteLib.webProxyInstance) {
+            global.tacoRemoteLib.webProxyInstance.kill();
+            global.tacoRemoteLib.webProxyInstance = null;
         }
 
         var portRange: string = util.format("null:%d,:%d-%d", this.webDebugProxyDevicePort, this.webDebugProxyPortMin, this.webDebugProxyPortMax);
         try {
-            this.webProxyInstance = child_process.spawn("ios_webkit_debug_proxy", ["-c", portRange]);
+            global.tacoRemoteLib.webProxyInstance = child_process.spawn("ios_webkit_debug_proxy", ["-c", portRange]);
         } catch (e) {
             res.status(404).send(resources.getStringForLanguage(req, "UnableToDebug"));
             return;

--- a/src/taco-remote-lib/ios/sharedState.ts
+++ b/src/taco-remote-lib/ios/sharedState.ts
@@ -1,0 +1,45 @@
+﻿/**
+﻿ *******************************************************
+﻿ *                                                     *
+﻿ *   Copyright (C) Microsoft. All rights reserved.     *
+﻿ *                                                     *
+﻿ *******************************************************
+﻿ */
+
+import child_process = require("child_process");
+
+class SharedState {
+    public static get webProxyInstance(): child_process.ChildProcess {
+        if (global.tacoRemoteLib) {
+            return global.tacoRemoteLib.webProxyInstance;
+        } else {
+            return null;
+        }
+    }
+
+    public static set webProxyInstance(proc: child_process.ChildProcess) {
+        if (!global.tacoRemoteLib) {
+            global.tacoRemoteLib = {};
+        }
+
+        global.tacoRemoteLib.webProxyInstance = proc;
+    }
+
+    public static get nativeDebuggerProxyInstance(): child_process.ChildProcess {
+        if (global.tacoRemoteLib) {
+            return global.tacoRemoteLib.nativeDebuggerProxyInstance;
+        } else {
+            return null;
+        }
+    }
+
+    public static set nativeDebuggerProxyInstance(proc: child_process.ChildProcess) {
+        if (!global.tacoRemoteLib) {
+            global.tacoRemoteLib = {};
+        }
+
+        global.tacoRemoteLib.nativeDebuggerProxyInstance = proc;
+    }
+}
+
+export = SharedState;


### PR DESCRIPTION
taco-remote-lib currently spawns two persistent processes for iOS related work: idevicedebugserverproxy and ios_webkit_debug_proxy. It keeps a hold of these processes in local variables, which starts to cause issues if we have multiple instances of the package around, such as now when we have different packages for cordova < 5.4.0 and >= 5.4.0

This change makes these processes into explicitly shared global state, allowing taco-remote-lib to share between packages.

This is one half of the change: identical changes are needed in taco-remote-lib@1.2.1