### PR TITLE
--accept parameter

### DIFF
--- a/src/taco-cli/cli/commands.json
+++ b/src/taco-cli/cli/commands.json
@@ -264,13 +264,18 @@
         ,
         "install-reqs":
         {
-            "synopsis": "<synopsis>[PLATFORM]</synopsis>",
+            "synopsis": "<synopsis>[PLATFORM] [--OPTIONS]</synopsis>",
             "categoryTitle": "[ProjectCommandsTitle]",
             "modulePath": "./installReqs",
             "description": "<helptitle>[CommandInstallReqsDescription]</helptitle>",
             "args": [
             {
                 "name": "[PLATFORM]", "description": "[CommandInstallReqsPlatformDescription]"
+            }
+            ],
+            "options": [
+            {
+                "name": "--accept", "description": "[CommandInstallReqsAcceptDescription]"
             }
             ]
         }

--- a/src/taco-cli/cli/commands.json
+++ b/src/taco-cli/cli/commands.json
@@ -275,7 +275,7 @@
             ],
             "options": [
             {
-                "name": "--no-prompt", "description": "[CommandInstallReqsAcceptDescription]"
+                "name": "--no-prompt", "description": "[CommandInstallReqsNoPromptDescription]"
             }
             ]
         }

--- a/src/taco-cli/cli/commands.json
+++ b/src/taco-cli/cli/commands.json
@@ -275,7 +275,7 @@
             ],
             "options": [
             {
-                "name": "--accept", "description": "[CommandInstallReqsAcceptDescription]"
+                "name": "--no-prompt", "description": "[CommandInstallReqsAcceptDescription]"
             }
             ]
         }

--- a/src/taco-cli/cli/taco.ts
+++ b/src/taco-cli/cli/taco.ts
@@ -161,8 +161,9 @@ class Taco {
     }
 
     private static parseArgs(args: string[]): IParsedArgs {
-        // Set the loglevel global setting
+        // Initialize global settings
         args = UtilHelper.initializeLogLevel(args);
+        args = UtilHelper.initializeAcceptPrompts(args);
 
         var commandName: string = null;
         var commandArgs: string[] = null;

--- a/src/taco-cli/cli/taco.ts
+++ b/src/taco-cli/cli/taco.ts
@@ -163,7 +163,7 @@ class Taco {
     private static parseArgs(args: string[]): IParsedArgs {
         // Initialize global settings
         args = UtilHelper.initializeLogLevel(args);
-        args = UtilHelper.initializeAcceptPrompts(args);
+        args = UtilHelper.initializeNoPrompt(args);
 
         var commandName: string = null;
         var commandArgs: string[] = null;

--- a/src/taco-cli/resources/en/resources.json
+++ b/src/taco-cli/resources/en/resources.json
@@ -393,7 +393,7 @@
     "CommandInstallReqsPlatformDescription": "A platform for which to install third-party dependencies",
     "_CommandInstallReqsPlatformDescription.comment": "Description for the [PLATFORM] option of 'taco install-reqs'",
     "CommandInstallReqsAcceptDescription": "Automatically accept all prompts (confirmation, license agreement and system variables overwrite)",
-    "_CommandInstallReqsAcceptDescription.comment": "Description for the [--accept] option of 'taco install-reqs'",
+    "_CommandInstallReqsAcceptDescription.comment": "Description for the [--no-prompt] option of 'taco install-reqs'",
 
     "CommandInstallNoPlatformsAdded": "Error: No platforms added to your project. To install the dependencies for a given platform, please add it to your project first.",
     "_CommandInstallNoPlatformsAdded.comment": "Error shown when a user uses 'taco install-reqs' but there are no platforms added to the current project.",

--- a/src/taco-cli/resources/en/resources.json
+++ b/src/taco-cli/resources/en/resources.json
@@ -392,8 +392,8 @@
     "_CommandInstallReqsDescription.comment": "Description for 'taco install-reqs'",
     "CommandInstallReqsPlatformDescription": "A platform for which to install third-party dependencies",
     "_CommandInstallReqsPlatformDescription.comment": "Description for the [PLATFORM] option of 'taco install-reqs'",
-    "CommandInstallReqsAcceptDescription": "Automatically accept all prompts (confirmation, license agreement and system variables overwrite)",
-    "_CommandInstallReqsAcceptDescription.comment": "Description for the [--no-prompt] option of 'taco install-reqs'",
+    "CommandInstallReqsNoPromptDescription": "Automatically accept all prompts (confirmation, license agreement and system variables overwrite)",
+    "_CommandInstallReqsNoPromptDescription.comment": "Description for the [--no-prompt] option of 'taco install-reqs'",
 
     "CommandInstallNoPlatformsAdded": "Error: No platforms added to your project. To install the dependencies for a given platform, please add it to your project first.",
     "_CommandInstallNoPlatformsAdded.comment": "Error shown when a user uses 'taco install-reqs' but there are no platforms added to the current project.",

--- a/src/taco-cli/resources/en/resources.json
+++ b/src/taco-cli/resources/en/resources.json
@@ -391,7 +391,9 @@
     "CommandInstallReqsDescription": "Install platform-specific third-party dependencies required to build",
     "_CommandInstallReqsDescription.comment": "Description for 'taco install-reqs'",
     "CommandInstallReqsPlatformDescription": "A platform for which to install third-party dependencies",
-    "_CommandInstallReqsPlatformDescription.comment": "Description for the [PLATFORM] option(s) of 'taco install-reqs'",
+    "_CommandInstallReqsPlatformDescription.comment": "Description for the [PLATFORM] option of 'taco install-reqs'",
+    "CommandInstallReqsAcceptDescription": "Automatically accept all prompts (confirmation / licenses agreement and system variable overwrite)",
+    "_CommandInstallReqsAcceptDescription.comment": "Description for the [--accept] option of 'taco install-reqs'",
 
     "CommandInstallNoPlatformsAdded": "Error: No platforms added to your project. To install the dependencies for a given platform, please add it to your project first.",
     "_CommandInstallNoPlatformsAdded.comment": "Error shown when a user uses 'taco install-reqs' but there are no platforms added to the current project.",

--- a/src/taco-cli/resources/en/resources.json
+++ b/src/taco-cli/resources/en/resources.json
@@ -392,7 +392,7 @@
     "_CommandInstallReqsDescription.comment": "Description for 'taco install-reqs'",
     "CommandInstallReqsPlatformDescription": "A platform for which to install third-party dependencies",
     "_CommandInstallReqsPlatformDescription.comment": "Description for the [PLATFORM] option of 'taco install-reqs'",
-    "CommandInstallReqsAcceptDescription": "Automatically accept all prompts (confirmation / licenses agreement and system variable overwrite)",
+    "CommandInstallReqsAcceptDescription": "Automatically accept all prompts (confirmation, license agreement and system variables overwrite)",
     "_CommandInstallReqsAcceptDescription.comment": "Description for the [--accept] option of 'taco install-reqs'",
 
     "CommandInstallNoPlatformsAdded": "Error: No platforms added to your project. To install the dependencies for a given platform, please add it to your project first.",

--- a/src/taco-dependency-installer/dependencyInstaller.ts
+++ b/src/taco-dependency-installer/dependencyInstaller.ts
@@ -375,7 +375,7 @@ module TacoDependencyInstaller {
             }
 
             // If we accept prompts automatically, then return immediately
-            if (TacoGlobalConfig.acceptPrompts) {
+            if (TacoGlobalConfig.noPrompt) {
                 return Q.resolve(true);
             }
 
@@ -518,7 +518,7 @@ module TacoDependencyInstaller {
                         utilHelper.quotesAroundIfNecessary(self.installConfigFilePath),
                         self.parentSessionId,
                         utilHelper.quotesAroundIfNecessary(DependencyInstaller.socketPath),
-                        TacoGlobalConfig.acceptPrompts ? "true" : "false"   // When launching a child process inside PowerShell, the environment is not preserved, so we need to pass this value on the command line
+                        TacoGlobalConfig.noPrompt ? "true" : "false"   // When launching a child process inside PowerShell, the environment is not preserved, so we need to pass this value on the command line
                     ];
                     var cp: childProcess.ChildProcess = childProcess.spawn(command, args, { stdio: "ignore" }); // Note: To workaround a Powershell hang on Windows 7, we set the stdio to ignore, otherwise Powershell never returns
 

--- a/src/taco-dependency-installer/dependencyInstaller.ts
+++ b/src/taco-dependency-installer/dependencyInstaller.ts
@@ -518,7 +518,7 @@ module TacoDependencyInstaller {
                         utilHelper.quotesAroundIfNecessary(self.installConfigFilePath),
                         self.parentSessionId,
                         utilHelper.quotesAroundIfNecessary(DependencyInstaller.socketPath),
-                        TacoGlobalConfig.acceptPrompts ? "true" : "false"
+                        TacoGlobalConfig.acceptPrompts ? "true" : "false"   // When launching a child process inside PowerShell, the environment is not preserved, so we need to pass this value on the command line
                     ];
                     var cp: childProcess.ChildProcess = childProcess.spawn(command, args, { stdio: "ignore" }); // Note: To workaround a Powershell hang on Windows 7, we set the stdio to ignore, otherwise Powershell never returns
 

--- a/src/taco-dependency-installer/dependencyInstaller.ts
+++ b/src/taco-dependency-installer/dependencyInstaller.ts
@@ -37,6 +37,7 @@ import IDependency = DependencyInstallerInterfaces.IDependency;
 import logger = tacoUtils.Logger;
 import loggerHelper = tacoUtils.LoggerHelper;
 import TacoErrorCodes = tacoErrorCodes.TacoErrorCode;
+import TacoGlobalConfig = tacoUtils.TacoGlobalConfig;
 import utilHelper = tacoUtils.UtilHelper;
 
 module TacoDependencyInstaller {
@@ -367,6 +368,11 @@ module TacoDependencyInstaller {
 
             if (needsLicenseAgreement) {
                 logger.log(resources.getString("LicenseAgreement"));
+            }
+
+            // If we accept prompts automatically, then return immediately
+            if (TacoGlobalConfig.acceptPrompts) {
+                return Q.resolve(true);
             }
 
             logger.log(resources.getString("InstallationProceedQuestion"));

--- a/src/taco-dependency-installer/dependencyInstaller.ts
+++ b/src/taco-dependency-installer/dependencyInstaller.ts
@@ -110,6 +110,10 @@ module TacoDependencyInstaller {
                 telemetry.step("promptUserBeforeInstall");
                 return this.promptUserBeforeInstall()
                     .then(function (acceptedPrompt: boolean): Q.Promise<number> {
+                        logger.logLine();
+                        loggerHelper.logSeparatorLine();
+                        logger.logLine();
+
                         if (acceptedPrompt) {
                             telemetry.step("spawnElevatedInstaller");
 
@@ -380,10 +384,6 @@ module TacoDependencyInstaller {
             return installerUtils.promptUser(resources.getString("YesExampleString"))
                 .then(function (answer: string): Q.Promise<any> {
                     if (answer.toLocaleLowerCase() === resources.getString("YesString")) {
-                        logger.logLine();
-                        loggerHelper.logSeparatorLine();
-                        logger.logLine();
-
                         return Q.resolve(true);
                     } else {
                         return Q.resolve(false);
@@ -517,7 +517,8 @@ module TacoDependencyInstaller {
                         utilHelper.quotesAroundIfNecessary(elevatedInstallerPath),
                         utilHelper.quotesAroundIfNecessary(self.installConfigFilePath),
                         self.parentSessionId,
-                        utilHelper.quotesAroundIfNecessary(DependencyInstaller.socketPath)
+                        utilHelper.quotesAroundIfNecessary(DependencyInstaller.socketPath),
+                        TacoGlobalConfig.acceptPrompts ? "true" : "false"
                     ];
                     var cp: childProcess.ChildProcess = childProcess.spawn(command, args, { stdio: "ignore" }); // Note: To workaround a Powershell hang on Windows 7, we set the stdio to ignore, otherwise Powershell never returns
 

--- a/src/taco-dependency-installer/elevatedInstaller.ts
+++ b/src/taco-dependency-installer/elevatedInstaller.ts
@@ -30,6 +30,7 @@ import tacoUtils = require ("taco-utils");
 
 import installerDataType = protocol.DataType;
 import protocolExitCode = protocol.ExitCode;
+import TacoGlobalConfig = tacoUtils.TacoGlobalConfig;
 import tacoLogger = tacoUtils.Logger;
 import TacoErrorCodes = tacoErrorCodes.TacoErrorCode;
 
@@ -103,6 +104,12 @@ class ElevatedInstaller {
         this.configFile = process.argv[2];
         this.parentSessionId = process.argv[3];
         this.socketPath = process.argv[4];
+
+        // Deal with auto-accept prompts; we need to reset this value, because on Windows we launch the elevated installer through PowerShell, and doing it that way does not carry over the env of the
+        // parent node.js process
+        if (process.argv[5] === "true") {
+            TacoGlobalConfig.acceptPrompts = true;
+        }
     }
 
     public run(): void {

--- a/src/taco-dependency-installer/elevatedInstaller.ts
+++ b/src/taco-dependency-installer/elevatedInstaller.ts
@@ -108,7 +108,7 @@ class ElevatedInstaller {
         // Deal with auto-accept prompts; we need to reset this value, because on Windows we launch the elevated installer through PowerShell, and doing it that way does not carry over the env of the
         // parent node.js process
         if (process.argv[5] === "true") {
-            TacoGlobalConfig.acceptPrompts = true;
+            TacoGlobalConfig.noPrompt = true;
         }
     }
 

--- a/src/taco-dependency-installer/utils/installerUtils.ts
+++ b/src/taco-dependency-installer/utils/installerUtils.ts
@@ -175,7 +175,7 @@ class InstallerUtils {
      */
     public static promptForEnvVariableOverwrite(name: string, socket: NodeJSNet.Socket): Q.Promise<string> {
         // If we auto-accept prompts, return with the YesString
-        if (TacoGlobalConfig.acceptPrompts) {
+        if (TacoGlobalConfig.noPrompt) {
             return Q.resolve(resources.getString("YesString"));
         }
 

--- a/src/taco-dependency-installer/utils/installerUtils.ts
+++ b/src/taco-dependency-installer/utils/installerUtils.ts
@@ -31,6 +31,7 @@ import resources = require ("../resources/resourceManager");
 import installerDataType = InstallerProtocol.DataType;
 import ILogger = InstallerProtocol.ILogger;
 import TacoErrorCodes = tacoErrorCodes.TacoErrorCode;
+import TacoGlobalConfig = tacoUtils.TacoGlobalConfig;
 import utils = tacoUtils.UtilHelper;
 
 module InstallerUtils {
@@ -173,8 +174,13 @@ class InstallerUtils {
      * @return {Q.Promise<string>} A promise resolved with a string containing the user's response to the prompt
      */
     public static promptForEnvVariableOverwrite(name: string, socket: NodeJSNet.Socket): Q.Promise<string> {
-        var deferred: Q.Deferred<string> = Q.defer<string>();
+        // If we auto-accept prompts, return with the YesString
+        if (TacoGlobalConfig.acceptPrompts) {
+            return Q.resolve(resources.getString("YesString"));
+        }
 
+        // Otherwise, we prompt the user
+        var deferred: Q.Deferred<string> = Q.defer<string>();
         var dataListener: (data: Buffer) => void = function (data: Buffer): void {
             var stringData: string = data.toString();
 

--- a/src/taco-dependency-installer/utils/win32/elevatedInstallerLauncher.ps1
+++ b/src/taco-dependency-installer/utils/win32/elevatedInstallerLauncher.ps1
@@ -4,7 +4,7 @@ $pinfo.FileName = "node.exe"
 $pinfo.UseShellExecute = $true
 $pinfo.WindowStyle = "Hidden"
 $pinfo.Verb = "RunAs"
-$pinfo.Arguments = "$args
+$pinfo.Arguments = "$args"
 
 $p = New-Object System.Diagnostics.Process
 $p.StartInfo = $pinfo

--- a/src/taco-dependency-installer/utils/win32/elevatedInstallerLauncher.ps1
+++ b/src/taco-dependency-installer/utils/win32/elevatedInstallerLauncher.ps1
@@ -4,7 +4,7 @@ $pinfo.FileName = "node.exe"
 $pinfo.UseShellExecute = $true
 $pinfo.WindowStyle = "Hidden"
 $pinfo.Verb = "RunAs"
-$pinfo.Arguments = "$($args[0]) $($args[1]) $($args[2]) $($args[3])"
+$pinfo.Arguments = "$args
 
 $p = New-Object System.Diagnostics.Process
 $p.StartInfo = $pinfo

--- a/src/taco-utils/tacoGlobalConfig.ts
+++ b/src/taco-utils/tacoGlobalConfig.ts
@@ -18,7 +18,7 @@ module TacoUtility {
     export class TacoGlobalConfig {
         private static LANG_NAME: string = "TACO_LANG";
         private static LOG_LEVEL_NAME: string = "TACO_LOG_LEVEL";
-        private static ACCEPT_PROMPTS_NAME: string = "TACO_ACCEPT_PROMPTS";
+        private static NO_PROMPT_NAME: string = "TACO_NO_PROMPT";
 
         public static get lang(): string {
             return process.env[TacoGlobalConfig.LANG_NAME];
@@ -44,12 +44,12 @@ module TacoUtility {
             process.env[TacoGlobalConfig.LOG_LEVEL_NAME] = LogLevel[level];
         }
 
-        public static get acceptPrompts(): boolean {
-            return process.env[TacoGlobalConfig.ACCEPT_PROMPTS_NAME] === "true";
+        public static get noPrompt(): boolean {
+            return process.env[TacoGlobalConfig.NO_PROMPT_NAME] === "true";
         }
 
-        public static set acceptPrompts(accept: boolean) {
-            process.env[TacoGlobalConfig.ACCEPT_PROMPTS_NAME] = accept;
+        public static set noPrompt(accept: boolean) {
+            process.env[TacoGlobalConfig.NO_PROMPT_NAME] = accept;
         }
     }
 }

--- a/src/taco-utils/tacoGlobalConfig.ts
+++ b/src/taco-utils/tacoGlobalConfig.ts
@@ -18,6 +18,7 @@ module TacoUtility {
     export class TacoGlobalConfig {
         private static LANG_NAME: string = "TACO_LANG";
         private static LOG_LEVEL_NAME: string = "TACO_LOG_LEVEL";
+        private static ACCEPT_PROMPTS_NAME: string = "TACO_ACCEPT_PROMPTS";
 
         public static get lang(): string {
             return process.env[TacoGlobalConfig.LANG_NAME];
@@ -41,6 +42,14 @@ module TacoUtility {
 
             // Save the string name of the enum value to process.env
             process.env[TacoGlobalConfig.LOG_LEVEL_NAME] = LogLevel[level];
+        }
+
+        public static get acceptPrompts(): boolean {
+            return process.env[TacoGlobalConfig.ACCEPT_PROMPTS_NAME] === "true";
+        }
+
+        public static set acceptPrompts(accept: boolean) {
+            process.env[TacoGlobalConfig.ACCEPT_PROMPTS_NAME] = accept;
         }
     }
 }

--- a/src/taco-utils/utilHelper.ts
+++ b/src/taco-utils/utilHelper.ts
@@ -368,7 +368,7 @@ module TacoUtility {
                 return args;
             }
 
-            // Note: Not using nopt to look for "--loglevel", because the autocmplete feature would catch things like "-l", when these may be intended for the command itself (not for taco loglevel).
+            // Note: Not using nopt to look for "--loglevel", because the autocomplete feature would catch things like "-l", when these may be intended for the command itself (not for taco loglevel).
             var logLevelTag: string = "--loglevel";
             var logLevelTagIndex: number = args.indexOf(logLevelTag);
 
@@ -393,6 +393,32 @@ module TacoUtility {
 
             // Clean up the --loglevel tag and its value, if present, from the args
             args.splice(logLevelTagIndex, 1 + (logLevelValueIndex === -1 ? 0 : 1));
+
+            return args;
+        }
+
+        /**
+         * Sets the global acceptPrompts setting for TACO by specifically looking for the "--accept" string in the given command args. If found, the "--accept" string is removed from the args so that
+         * it is not passed to the command.
+         *
+         * @param {string[]} args The command line args to parse in order to find the --loglevel parameter
+         * @return {string[]} The args where --loglevel and its value have been removed
+         */
+        public static initializeAcceptPrompts(args: string[]): string[] {
+            if (!args) {
+                return args;
+            }
+
+            // Note: Not using nopt to look for "--accept", because the autocomplete feature would catch things like "-a", when these may be intended for the command itself (not for taco acceptPrompts).
+            var acceptTag: string = "--accept";
+            var acceptTagIndex: number = args.indexOf(acceptTag);
+
+            if (acceptTagIndex === -1) {
+                return args;
+            }
+
+            TacoGlobalConfig.acceptPrompts = true;
+            args.splice(acceptTagIndex, 1);
 
             return args;
         }

--- a/src/taco-utils/utilHelper.ts
+++ b/src/taco-utils/utilHelper.ts
@@ -404,20 +404,20 @@ module TacoUtility {
          * @param {string[]} args The command line args to parse in order to find the --loglevel parameter
          * @return {string[]} The args where --loglevel and its value have been removed
          */
-        public static initializeAcceptPrompts(args: string[]): string[] {
+        public static initializeNoPrompt(args: string[]): string[] {
             if (!args) {
                 return args;
             }
 
             // Note: Not using nopt to look for "--accept", because the autocomplete feature would catch things like "-a", when these may be intended for the command itself (not for taco acceptPrompts).
-            var acceptTag: string = "--accept";
+            var acceptTag: string = "--no-prompt";
             var acceptTagIndex: number = args.indexOf(acceptTag);
 
             if (acceptTagIndex === -1) {
                 return args;
             }
 
-            TacoGlobalConfig.acceptPrompts = true;
+            TacoGlobalConfig.noPrompt = true;
             args.splice(acceptTagIndex, 1);
 
             return args;

--- a/src/typings/tacoGlobalConfig.d.ts
+++ b/src/typings/tacoGlobalConfig.d.ts
@@ -10,6 +10,6 @@ declare module TacoUtility {
     class TacoGlobalConfig {
         public static lang: string;
         public static logLevel: LogLevel;
-        public static acceptPrompts: boolean;
+        public static noPrompt: boolean;
     }
 }

--- a/src/typings/tacoGlobalConfig.d.ts
+++ b/src/typings/tacoGlobalConfig.d.ts
@@ -10,5 +10,6 @@ declare module TacoUtility {
     class TacoGlobalConfig {
         public static lang: string;
         public static logLevel: LogLevel;
+        public static acceptPrompts: boolean;
     }
 }

--- a/src/typings/utilHelper.d.ts
+++ b/src/typings/utilHelper.d.ts
@@ -121,7 +121,14 @@ declare module TacoUtility {
          * @return {string[]} The args where --loglevel and its value have been removed
          */
         public static initializeLogLevel(args: string[]): string[];
-
+        /**
+         * Sets the global acceptPrompts setting for TACO by specifically looking for the "--accept" string in the given command args. If found, the "--accept" string is removed from the args so that
+         * it is not passed to the command.
+         *
+         * @param {string[]} args The command line args to parse in order to find the --loglevel parameter
+         * @return {string[]} The args where --loglevel and its value have been removed
+         */
+        public static initializeAcceptPrompts(args: string[]): string[];
         /**
          * An explicit helper empty method, which can be used in scenarios like
          * silent callbacks, catch all exceptions do nothing etc.

--- a/src/typings/utilHelper.d.ts
+++ b/src/typings/utilHelper.d.ts
@@ -128,7 +128,7 @@ declare module TacoUtility {
          * @param {string[]} args The command line args to parse in order to find the --loglevel parameter
          * @return {string[]} The args where --loglevel and its value have been removed
          */
-        public static initializeAcceptPrompts(args: string[]): string[];
+        public static initializeNoPrompt(args: string[]): string[];
         /**
          * An explicit helper empty method, which can be used in scenarios like
          * silent callbacks, catch all exceptions do nothing etc.


### PR DESCRIPTION
Added a global ~~--accept~~ **Edit: changed to --no-prompt** parameter that gets saved in TacoGlobalConfig. This can be used by packages to react accordingly when prompting the user.

Also made DependencyInstaller honor that parameter.