### PR TITLE
Adding missing require

### DIFF
--- a/src/taco-remote-lib/ios/ios.ts
+++ b/src/taco-remote-lib/ios/ios.ts
@@ -7,7 +7,6 @@
 ﻿ */
 
 /// <reference path="../../typings/node.d.ts" />
-/// <reference path="../../typings/Q.d.ts" />
 /// <reference path="../../typings/tacoUtils.d.ts" />
 /// <reference path="../../typings/zip-stream.d.ts" />
 /// <reference path="../../typings/express.d.ts" />
@@ -19,6 +18,7 @@ import child_process = require ("child_process");
 import fs = require ("fs");
 import net = require ("net");
 import path = require ("path");
+import Q = require ("q");
 import util = require ("util");
 import Packer = require ("zip-stream");
 


### PR DESCRIPTION
Currently trying to set up a debug pathway will throw an exception due to a missing require. This fix also needs to apply to taco-remote-lib 1.2.1