### PR TITLE
Changing definition of 'eligible for deletion' to only exclude builds in progress

### DIFF
--- a/src/taco-remote/lib/buildRetention.ts
+++ b/src/taco-remote/lib/buildRetention.ts
@@ -60,9 +60,7 @@ class BuildRetention {
         var eligibleBuilds: utils.BuildInfo[] = [];
         for (var i: number = 0; i < buildNumbers.length; i++) {
             var buildInfo: utils.BuildInfo = builds[buildNumbers[i]];
-            if (buildInfo.status === utils.BuildInfo.COMPLETE || buildInfo.status === utils.BuildInfo.DOWNLOADED ||
-                buildInfo.status === utils.BuildInfo.ERROR || buildInfo.status === utils.BuildInfo.EMULATED ||
-                buildInfo.status === utils.BuildInfo.INVALID) {
+            if ([utils.BuildInfo.BUILDING, utils.BuildInfo.EXTRACTED, utils.BuildInfo.UPLOADING, utils.BuildInfo.UPLOADED].indexOf(buildInfo.status) !== -1) {
                 eligibleBuilds.push(buildInfo);
             }
         };

--- a/src/taco-remote/lib/buildRetention.ts
+++ b/src/taco-remote/lib/buildRetention.ts
@@ -20,6 +20,7 @@ import utils = require ("taco-utils");
 import Logger = utils.Logger;
 
 class BuildRetention {
+    private static statesToNotDelete = [utils.BuildInfo.BUILDING, utils.BuildInfo.EXTRACTED, utils.BuildInfo.UPLOADING, utils.BuildInfo.UPLOADED];
     private maxBuildsToKeep: number;
 
     constructor(baseBuildDir: string, config: TacoRemoteConfig) {
@@ -60,7 +61,7 @@ class BuildRetention {
         var eligibleBuilds: utils.BuildInfo[] = [];
         for (var i: number = 0; i < buildNumbers.length; i++) {
             var buildInfo: utils.BuildInfo = builds[buildNumbers[i]];
-            if ([utils.BuildInfo.BUILDING, utils.BuildInfo.EXTRACTED, utils.BuildInfo.UPLOADING, utils.BuildInfo.UPLOADED].indexOf(buildInfo.status) !== -1) {
+            if (BuildRetention.statesToNotDelete.indexOf(buildInfo.status) === -1) {
                 eligibleBuilds.push(buildInfo);
             }
         };


### PR DESCRIPTION
Currently the criteria for deleting a build excludes "installed" or "debugging" builds, which mean they clog up the pipeline. The more specific criteria below excludes only builds that are currently queued for building or actually building.