### PR TITLE
Add Telemetry to Remotebuild

### DIFF
--- a/src/remotebuild/lib/cli.ts
+++ b/src/remotebuild/lib/cli.ts
@@ -23,6 +23,7 @@ import hostSpecifics = require ("./hostSpecifics");
 import RemoteBuildConf = require ("./remoteBuildConf");
 import resources = require ("../resources/resourceManager");
 import utils = require ("taco-utils");
+import telemetry = utils.Telemetry;
 
 import HostSpecifics = hostSpecifics.hostSpecifics;
 import Logger = utils.Logger;
@@ -38,6 +39,9 @@ class CliHelper {
             .then(function (): void {
                 // if version flag found, show version and exit
                 CliHelper.handleVersionFlag(args);
+            })
+            .then(function(): Q.Promise<any> {
+                return telemetry.init("REMOTE_BUILD", require("../package.json").version);
             })
             .then(function (): Q.Promise<void> {
                 remotebuildConf = CliHelper.parseRemoteBuildConf();

--- a/src/remotebuild/lib/cli.ts
+++ b/src/remotebuild/lib/cli.ts
@@ -41,7 +41,7 @@ class CliHelper {
                 CliHelper.handleVersionFlag(args);
             })
             .then(function(): Q.Promise<any> {
-                return telemetry.init("REMOTE_BUILD", require("../package.json").version);
+                return telemetry.init("REMOTEBUILD", require("../package.json").version, undefined ,"RemotebuildTelemetrySettings.json");
             })
             .then(function (): Q.Promise<void> {
                 remotebuildConf = CliHelper.parseRemoteBuildConf();

--- a/src/remotebuild/lib/cli.ts
+++ b/src/remotebuild/lib/cli.ts
@@ -41,7 +41,7 @@ class CliHelper {
                 CliHelper.handleVersionFlag(args);
             })
             .then(function(): Q.Promise<any> {
-                return telemetry.init("REMOTEBUILD", require("../package.json").version, undefined ,"RemotebuildTelemetrySettings.json");
+                return telemetry.init("REMOTEBUILD", require("../package.json").version, {settingsFileName: "RemotebuildTelemetrySettings.json"});
             })
             .then(function (): Q.Promise<void> {
                 remotebuildConf = CliHelper.parseRemoteBuildConf();

--- a/src/remotebuild/lib/server.ts
+++ b/src/remotebuild/lib/server.ts
@@ -73,14 +73,12 @@ class Server {
         app.get("/certs/:pin", HostSpecifics.hostSpecifics.downloadClientCerts);
         app.get("/modules/:module", Server.getModuleMount);
 
-        return utils.TelemetryHelper.generate("Server",
+        return utils.TelemetryHelper.generate("start",
                     (telemetry: utils.TelemetryGenerator) => {
                         telemetry
-                            .add("remoteBuild.server.OS.platform", os.platform(), false)
-                            .add("remoteBuild.server.OS.version", os.release(), false)
-                            .add("remoteBuild.server.isSecure", conf.secure, false)
-                            .add("remoteBuild.server.nodeVersion", process.version, false);
-                            /*.add("remoteBuild.server.npmVersion", "", false);*/
+                            .add("remotebuildVersion", require("../package.json").version, false)
+                            .add("isSecure", conf.secure, false)
+                            .add("nodeVersion", process.version.indexOf("v") === 0 ? process.version.slice(1) : process.version, false);
                             
                     return Server.initializeServerCapabilities(conf).then(function (serverCapabilities: RemoteBuild.IServerCapabilities): Q.Promise<any> {
                         return Server.loadServerModules(conf, app, serverCapabilities);

--- a/src/remotebuild/lib/server.ts
+++ b/src/remotebuild/lib/server.ts
@@ -76,7 +76,6 @@ class Server {
         return utils.TelemetryHelper.generate("start",
                     (telemetry: utils.TelemetryGenerator) => {
                         telemetry
-                            .add("remotebuildVersion", require("../package.json").version, false)
                             .add("isSecure", conf.secure, false)
                             .add("nodeVersion", process.version.indexOf("v") === 0 ? process.version.slice(1) : process.version, false);
                             

--- a/src/remotebuild/lib/server.ts
+++ b/src/remotebuild/lib/server.ts
@@ -28,6 +28,7 @@ import path = require ("path");
 import Q = require ("q");
 import semver = require ("semver");
 import util = require ("util");
+import os = require("os");
 
 import HostSpecifics = require ("./hostSpecifics");
 import RemoteBuildConf = require ("./remoteBuildConf");
@@ -72,21 +73,31 @@ class Server {
         app.get("/certs/:pin", HostSpecifics.hostSpecifics.downloadClientCerts);
         app.get("/modules/:module", Server.getModuleMount);
 
-        return Server.initializeServerCapabilities(conf).then(function (serverCapabilities: RemoteBuild.IServerCapabilities): Q.Promise<any> {
-            return Server.loadServerModules(conf, app, serverCapabilities);
-        }).then(function (): Q.Promise<any> {
-            return Server.startupServer(conf, app);
-        }).then(Server.registerShutdownHooks).then(function (): void {
-            Logger.log(resources.getString("CheckSettingsForInfo", conf.configFileLocation));
-        })
-          .fail(function (err: any): void {
-            Logger.logError(resources.getString("ServerStartFailed", err));
-            if (err.stack) {
-                Logger.logError(err.stack);
-            }
-
-            throw err;
-        });
+        return utils.TelemetryHelper.generate("Server",
+                    (telemetry: utils.TelemetryGenerator) => {
+                        telemetry
+                            .add("remoteBuild.server.OS.platform", os.platform(), false)
+                            .add("remoteBuild.server.OS.version", os.release(), false)
+                            .add("remoteBuild.server.isSecure", conf.secure, false)
+                            .add("remoteBuild.server.nodeVersion", process.version, false);
+                            /*.add("remoteBuild.server.npmVersion", "", false);*/
+                            
+                    return Server.initializeServerCapabilities(conf).then(function (serverCapabilities: RemoteBuild.IServerCapabilities): Q.Promise<any> {
+                        return Server.loadServerModules(conf, app, serverCapabilities);
+                    }).then(function (): Q.Promise<any> {
+                        return Server.startupServer(conf, app);
+                    }).then(Server.registerShutdownHooks).then(function (): void {
+                        Logger.log(resources.getString("CheckSettingsForInfo", conf.configFileLocation));
+                    })
+                    .fail(function (err: any): void {
+                        Logger.logError(resources.getString("ServerStartFailed", err));
+                        if (err.stack) {
+                            Logger.logError(err.stack);
+                        }
+            
+                        throw err;
+                    });
+            });
     }
 
     public static stop(callback?: Function): void {

--- a/src/taco-cli/cli/taco.ts
+++ b/src/taco-cli/cli/taco.ts
@@ -65,7 +65,7 @@ class Taco {
 
             return Settings.saveSettings({});
         }).then(function(settings: Settings.ISettings): Q.Promise<any> {
-            return telemetry.init("TACO", require("../package.json").version, {});
+            return telemetry.init("TACO", require("../package.json").version);
         }).then(function(): Q.Promise<any> {
             TacoGlobalConfig.lang = "en"; // Disable localization for now so we don't get partially localized content.
 

--- a/src/taco-cli/cli/taco.ts
+++ b/src/taco-cli/cli/taco.ts
@@ -65,7 +65,7 @@ class Taco {
 
             return Settings.saveSettings({});
         }).then(function(settings: Settings.ISettings): Q.Promise<any> {
-            return telemetry.init("TACO", require("../package.json").version);
+            return telemetry.init("TACO", require("../package.json").version, {});
         }).then(function(): Q.Promise<any> {
             TacoGlobalConfig.lang = "en"; // Disable localization for now so we don't get partially localized content.
 

--- a/src/taco-dependency-installer/elevatedInstaller.ts
+++ b/src/taco-dependency-installer/elevatedInstaller.ts
@@ -113,7 +113,7 @@ class ElevatedInstaller {
     }
 
     public run(): void {
-        tacoUtils.Telemetry.init("TACO/dependencyInstaller", require("./package.json").version, this.parentSessionId !== "null");
+        tacoUtils.Telemetry.init("TACO/dependencyInstaller", require("./package.json").version, {isOptedIn: this.parentSessionId !== "null"});
         tacoUtils.Telemetry.setSessionId(this.parentSessionId);
         tacoUtils.TelemetryHelper.generate("ElevatedInstaller", (telemetry: tacoUtils.TelemetryGenerator) => {
             var self: ElevatedInstaller = this;

--- a/src/taco-dependency-installer/test/androidPackagesInstaller.ts
+++ b/src/taco-dependency-installer/test/androidPackagesInstaller.ts
@@ -90,7 +90,7 @@ describe("AndroidPackagesInstaller telemetry", () => {
 
         mockery.registerMock("./processUtils", fakeProcessUtilsModule); // TelemetryHelper loads ./processUtils
         var tacoUtils: typeof TacoUtility = require("taco-utils");
-        tacoUtils.Telemetry.init("TACO/dependencyInstaller", "1.2.3", false);
+        tacoUtils.Telemetry.init("TACO/dependencyInstaller", "1.2.3", {isOptedIn: false});
 
         // Register mocks. child_process and taco-utils mocks needs to be registered before 
         // AndroidSdkInstaller is required for the mocking to work

--- a/src/taco-dependency-installer/test/androidSdkInstaller.ts
+++ b/src/taco-dependency-installer/test/androidSdkInstaller.ts
@@ -69,7 +69,7 @@ describe("AndroidSdkInstaller telemetry", () => {
 
         mockery.registerMock("./processUtils", fakeProcessUtilsModule); // TelemetryHelper loads ./processUtils
         var tacoUtils: typeof TacoUtility = require("taco-utils");
-        tacoUtils.Telemetry.init("TACO/dependencyInstaller", "1.2.3", false);
+        tacoUtils.Telemetry.init("TACO/dependencyInstaller", "1.2.3", {isOptedIn: false});
 
         // Register mocks. child_process and taco-utils mocks needs to be registered before 
         // AndroidSdkInstaller is required for the mocking to work

--- a/src/taco-dependency-installer/test/installerRunner.ts
+++ b/src/taco-dependency-installer/test/installerRunner.ts
@@ -380,7 +380,7 @@ describe("InstallerRunner", function (): void {
 
             mockery.registerMock("./processUtils", fakeProcessUtilsModule); // TelemetryHelper loads ./processUtils
             var tacoUtils: typeof TacoUtility = require("taco-utils");
-            tacoUtils.Telemetry.init("TACO/dependencyInstaller", "1.2.3", false);
+            tacoUtils.Telemetry.init("TACO/dependencyInstaller", "1.2.3", {isOptedIn: false});
 
             // Register mocks. child_process and taco-utils mocks needs to be registered before 
             // AndroidSdkInstaller is required for the mocking to work

--- a/src/taco-dependency-installer/test/javaJdkInstaller.ts
+++ b/src/taco-dependency-installer/test/javaJdkInstaller.ts
@@ -68,7 +68,7 @@ describe("JavaJdkInstaller telemetry", () => {
         mockery.registerMock("./processUtils", fakeProcessUtilsModule); // TelemetryHelper and Resources loads ./processUtils
         var tacoUtilsWithFakes: typeof TacoUtility = require("taco-utils"); // Reload taco utils with mocks
 
-        tacoUtilsWithFakes.Telemetry.init("TACO/dependencyInstaller", "1.2.3", false);
+        tacoUtilsWithFakes.Telemetry.init("TACO/dependencyInstaller", "1.2.3", {isOptedIn: false});
 
         // Register mocks. child_process and taco-utils mocks needs to be registered before 
         // javaJdkInstaller is required for the mocking to work

--- a/src/taco-remote/lib/buildManager.ts
+++ b/src/taco-remote/lib/buildManager.ts
@@ -159,6 +159,20 @@ class BuildManager {
                 if (err) {
                     deferred.reject(err);
                 } else {
+                    
+                    utils.TelemetryHelper.generate("Server",
+                    (telemetry: utils.TelemetryGenerator) => {
+                        telemetry
+                            .add("remoteBuild.server.build.cordovaVersion", buildInfo["vcordova"], false)
+                            /*.add("remoteBuild.server.build.wasBuildSuccessful", "", false)*/
+                            .add("remoteBuild.server.build.locale", buildInfo.buildLang, false)
+                            /*.add("remoteBuild.server.build.iosVersion", "", false)*/
+                            .add("remoteBuild.server.build.buildSize", fs.statSync(buildInfo.tgzFilePath)["size"], false)
+                            .add("remoteBuild.server.build.queueSize", self.queuedBuilds.length, false)
+                            /*.add("remoteBuild.server.build.maintainedBuildsSize", "", false)*/
+                            .add("remoteBuild.server.build.isDeviceBuild", self.currentBuild.options.indexOf("--device") !== -1, false);
+                    });
+                    
                     deferred.resolve(buildInfo);
                     self.beginBuild(req, buildInfo);
                 }

--- a/src/taco-remote/lib/buildManager.ts
+++ b/src/taco-remote/lib/buildManager.ts
@@ -161,17 +161,15 @@ class BuildManager {
                     deferred.reject(err);
                 } else {
                     
-                    utils.TelemetryHelper.generate("Server",
+                    utils.TelemetryHelper.generate("build",
                     (telemetry: utils.TelemetryGenerator) => {
                         self.telemetry = telemetry;
                         self.telemetry
-                            .add("remoteBuild.server.build.cordovaVersion", buildInfo["vcordova"], false)
-                            .add("remoteBuild.server.build.locale", buildInfo.buildLang, false)
-                            /*.add("remoteBuild.server.build.iosVersion", "", false)*/
-                            .add("remoteBuild.server.build.buildSize", fs.statSync(buildInfo.tgzFilePath)["size"], false)
-                            .add("remoteBuild.server.build.queueSize", self.queuedBuilds.length, false)
-                            /*.add("remoteBuild.server.build.maintainedBuildsSize", "", false)*/
-                            .add("remoteBuild.server.build.isDeviceBuild", self.currentBuild.options.indexOf("--device") !== -1, false);
+                            .add("cordovaVersion", buildInfo["vcordova"], false)
+                            .add("locale", buildInfo.buildLang, false)
+                            .add("zippedFileSize", fs.statSync(buildInfo.tgzFilePath)["size"], false)
+                            .add("queueSize", self.queuedBuilds.length, false)
+                            .add("isDeviceBuild", self.currentBuild.options.indexOf("--device") !== -1, false);
                             
                             deferred.resolve(buildInfo);
                             self.beginBuild(req, buildInfo);
@@ -447,7 +445,7 @@ class BuildManager {
                     self.buildMetrics.failed++;
                 }
                 
-                self.telemetry.add("remoteBuild.server.build.wasBuildSuccessful", buildInfo.status === BuildInfo.COMPLETE, false);
+                self.telemetry.add("wasBuildSuccessful", buildInfo.status === BuildInfo.COMPLETE, false);
 
                 self.dequeueNextBuild();
             });

--- a/src/taco-remote/lib/buildManager.ts
+++ b/src/taco-remote/lib/buildManager.ts
@@ -160,20 +160,8 @@ class BuildManager {
                 if (err) {
                     deferred.reject(err);
                 } else {
-                    
-                    utils.TelemetryHelper.generate("build",
-                    (telemetry: utils.TelemetryGenerator) => {
-                        self.telemetry = telemetry;
-                        self.telemetry
-                            .add("cordovaVersion", buildInfo["vcordova"], false)
-                            .add("locale", buildInfo.buildLang, false)
-                            .add("zippedFileSize", fs.statSync(buildInfo.tgzFilePath)["size"], false)
-                            .add("queueSize", self.queuedBuilds.length, false)
-                            .add("isDeviceBuild", self.currentBuild.options.indexOf("--device") !== -1, false);
-                            
-                            deferred.resolve(buildInfo);
-                            self.beginBuild(req, buildInfo);
-                    });
+                    deferred.resolve(buildInfo);
+                    self.beginBuild(req, buildInfo);
                 }
             });
             return deferred.promise;
@@ -445,7 +433,16 @@ class BuildManager {
                     self.buildMetrics.failed++;
                 }
                 
-                self.telemetry.add("wasBuildSuccessful", buildInfo.status === BuildInfo.COMPLETE, false);
+                utils.TelemetryHelper.generate("build",
+                    (telemetry: utils.TelemetryGenerator) => {
+                        telemetry
+                            .add("cordovaVersion", buildInfo["vcordova"], false)
+                            .add("locale", buildInfo.buildLang, false)
+                            .add("zippedFileSize", fs.statSync(buildInfo.tgzFilePath)["size"], false)
+                            .add("queueSize", self.queuedBuilds.length, false)
+                            .add("isDeviceBuild", self.currentBuild.options.indexOf("--device") !== -1, false)
+                            .add("wasBuildSuccessful", buildInfo.status === BuildInfo.COMPLETE, false);
+                    });
 
                 self.dequeueNextBuild();
             });

--- a/src/taco-utils/telemetry.ts
+++ b/src/taco-utils/telemetry.ts
@@ -111,7 +111,7 @@ module TacoUtility {
             }
         };
 
-        export function init(appNameValue: string, appVersion: string, telemetryOptions: ITelemetryOptions): Q.Promise<any> {
+        export function init(appNameValue: string, appVersion: string, telemetryOptions: ITelemetryOptions = {}): Q.Promise<any> {
             try {
                 Telemetry.appName = appNameValue;
                 return TelemetryUtils.init(appVersion, telemetryOptions);

--- a/src/taco-utils/telemetry.ts
+++ b/src/taco-utils/telemetry.ts
@@ -106,10 +106,10 @@ module TacoUtility {
             }
         };
 
-        export function init(appNameValue: string, appVersion?: string, isOptedInValue?: boolean): Q.Promise<any> {
+        export function init(appNameValue: string, appVersion?: string, isOptedInValue?: boolean, telemetrySettingsFileName?: string): Q.Promise<any> {
             try {
                 Telemetry.appName = appNameValue;
-                return TelemetryUtils.init(appVersion, isOptedInValue);
+                return TelemetryUtils.init(appVersion, isOptedInValue, telemetrySettingsFileName);
             } catch (err) {
                 if (TacoGlobalConfig.logLevel === LogLevel.Diagnostic && err) {
                     logger.logError(err);
@@ -196,8 +196,8 @@ module TacoUtility {
             private static userId: string;
             private static machineId: string;
             private static telemetrySettings: ITelemetrySettings = null;
-            private static TELEMETRY_SETTINGS_FILENAME: string = "TelemetrySettings.json";
-            private static REMOTEBUILD_TELEMETRY_SETTINGS_FILENAME: string = "RemotebuildTelemetrySettings.json";
+            private static telemetrySettingsFileName: string;
+            private static DEFAULT_TELEMETRY_SETTINGS_FILENAME: string = "TelemetrySettings.json";
             private static APPINSIGHTS_INSTRUMENTATIONKEY: string = "10baf391-c2e3-4651-a726-e9b25d8470fd";
             private static REGISTRY_SQMCLIENT_NODE: string = "\\SOFTWARE\\Microsoft\\SQMClient";
             private static REGISTRY_USERID_VALUE: string = "UserId";
@@ -206,14 +206,12 @@ module TacoUtility {
             private static INTERNAL_USER_ENV_VAR: string = "TACOINTERNAL";
 
             private static get telemetrySettingsFile(): string {
-                if (Telemetry.appName === "REMOTE_BUILD") {
-                    return path.join(UtilHelper.tacoHome, TelemetryUtils.REMOTEBUILD_TELEMETRY_SETTINGS_FILENAME); 
-                }
-                
-                return path.join(UtilHelper.tacoHome, TelemetryUtils.TELEMETRY_SETTINGS_FILENAME);
+                return path.join(UtilHelper.tacoHome, TelemetryUtils.telemetrySettingsFileName);
             }
 
-            public static init(appVersion: string, isOptedInValue?: boolean): Q.Promise<any> {
+            public static init(appVersion: string, isOptedInValue?: boolean, telemetrySettingsFileName?: string): Q.Promise<any> {
+                TelemetryUtils.telemetrySettingsFileName = telemetrySettingsFileName || TelemetryUtils.DEFAULT_TELEMETRY_SETTINGS_FILENAME;
+                
                 TelemetryUtils.loadSettings();
 
                 appInsights.setup(TelemetryUtils.APPINSIGHTS_INSTRUMENTATIONKEY)

--- a/src/taco-utils/telemetry.ts
+++ b/src/taco-utils/telemetry.ts
@@ -49,6 +49,11 @@ module TacoUtility {
         export interface ITelemetryProperties {
             [propertyName: string]: any;
         };
+        
+        export interface ITelemetryOptions {
+            isOptedIn?: boolean;
+            settingsFileName?: string;  
+        };
 
         /**
          * TelemetryEvent represents a basic telemetry data point
@@ -106,10 +111,10 @@ module TacoUtility {
             }
         };
 
-        export function init(appNameValue: string, appVersion?: string, isOptedInValue?: boolean, telemetrySettingsFileName?: string): Q.Promise<any> {
+        export function init(appNameValue: string, appVersion: string, telemetryOptions: ITelemetryOptions): Q.Promise<any> {
             try {
                 Telemetry.appName = appNameValue;
-                return TelemetryUtils.init(appVersion, isOptedInValue, telemetrySettingsFileName);
+                return TelemetryUtils.init(appVersion, telemetryOptions);
             } catch (err) {
                 if (TacoGlobalConfig.logLevel === LogLevel.Diagnostic && err) {
                     logger.logError(err);
@@ -209,8 +214,8 @@ module TacoUtility {
                 return path.join(UtilHelper.tacoHome, TelemetryUtils.telemetrySettingsFileName);
             }
 
-            public static init(appVersion: string, isOptedInValue?: boolean, telemetrySettingsFileName?: string): Q.Promise<any> {
-                TelemetryUtils.telemetrySettingsFileName = telemetrySettingsFileName || TelemetryUtils.DEFAULT_TELEMETRY_SETTINGS_FILENAME;
+            public static init(appVersion: string, telemetryOptions: ITelemetryOptions): Q.Promise<any> {
+                TelemetryUtils.telemetrySettingsFileName = telemetryOptions.settingsFileName || TelemetryUtils.DEFAULT_TELEMETRY_SETTINGS_FILENAME;
                 
                 TelemetryUtils.loadSettings();
 
@@ -237,14 +242,14 @@ module TacoUtility {
                     TelemetryUtils.sessionId = TelemetryUtils.generateGuid();
                     TelemetryUtils.userType = TelemetryUtils.getUserType();
                 }).then(function() : Q.Promise<any> {
-                    if (_.isUndefined(isOptedInValue)) {
+                    if (_.isUndefined(telemetryOptions.isOptedIn)) {
                         return TelemetryUtils.getOptIn()
                         .then(function (optIn: boolean): void {
                             Telemetry.isOptedIn = optIn;
                             TelemetryUtils.saveSettings();
                         });
                     } else {
-                        Telemetry.isOptedIn = isOptedInValue;
+                        Telemetry.isOptedIn = telemetryOptions.isOptedIn;
                         TelemetryUtils.saveSettings();
                         return Q({});
                     }

--- a/src/taco-utils/telemetry.ts
+++ b/src/taco-utils/telemetry.ts
@@ -197,6 +197,7 @@ module TacoUtility {
             private static machineId: string;
             private static telemetrySettings: ITelemetrySettings = null;
             private static TELEMETRY_SETTINGS_FILENAME: string = "TelemetrySettings.json";
+            private static REMOTEBUILD_TELEMETRY_SETTINGS_FILENAME: string = "RemotebuildTelemetrySettings.json";
             private static APPINSIGHTS_INSTRUMENTATIONKEY: string = "10baf391-c2e3-4651-a726-e9b25d8470fd";
             private static REGISTRY_SQMCLIENT_NODE: string = "\\SOFTWARE\\Microsoft\\SQMClient";
             private static REGISTRY_USERID_VALUE: string = "UserId";
@@ -205,6 +206,10 @@ module TacoUtility {
             private static INTERNAL_USER_ENV_VAR: string = "TACOINTERNAL";
 
             private static get telemetrySettingsFile(): string {
+                if (Telemetry.appName === "REMOTE_BUILD") {
+                    return path.join(UtilHelper.tacoHome, TelemetryUtils.REMOTEBUILD_TELEMETRY_SETTINGS_FILENAME); 
+                }
+                
                 return path.join(UtilHelper.tacoHome, TelemetryUtils.TELEMETRY_SETTINGS_FILENAME);
             }
 

--- a/src/typings/telemetry.d.ts
+++ b/src/typings/telemetry.d.ts
@@ -16,6 +16,11 @@ declare module TacoUtility {
         interface ITelemetryProperties {
             [propertyName: string]: any;
         }
+        
+        interface ITelemetryOptions {
+            isOptedIn?: boolean;
+            settingsFileName?: string;  
+        }
         /**
          * TelemetryEvent represents a basic telemetry data point
          */
@@ -39,7 +44,7 @@ declare module TacoUtility {
             start(): void;
             end(): void;
         }
-        function init(appName: string, appVersion?: string, isOptedIn?: boolean, telemetrySettingsFileName?: string): Q.Promise<any>;
+        function init(appName: string, appVersion: string, telemetryOptions: ITelemetryOptions): Q.Promise<any>;
         function isInternal(): boolean;
         function send(event: TelemetryEvent, ignoreOptIn?: boolean): void;
         function changeTelemetryOptInSetting(): Q.Promise<any>;

--- a/src/typings/telemetry.d.ts
+++ b/src/typings/telemetry.d.ts
@@ -39,7 +39,7 @@ declare module TacoUtility {
             start(): void;
             end(): void;
         }
-        function init(appName: string, appVersion?: string, isOptedIn?: boolean): Q.Promise<any>;
+        function init(appName: string, appVersion?: string, isOptedIn?: boolean, telemetrySettingsFileName?: string): Q.Promise<any>;
         function isInternal(): boolean;
         function send(event: TelemetryEvent, ignoreOptIn?: boolean): void;
         function changeTelemetryOptInSetting(): Q.Promise<any>;

--- a/src/typings/telemetry.d.ts
+++ b/src/typings/telemetry.d.ts
@@ -44,7 +44,7 @@ declare module TacoUtility {
             start(): void;
             end(): void;
         }
-        function init(appName: string, appVersion: string, telemetryOptions: ITelemetryOptions): Q.Promise<any>;
+        function init(appName: string, appVersion: string, telemetryOptions?: ITelemetryOptions): Q.Promise<any>;
         function isInternal(): boolean;
         function send(event: TelemetryEvent, ignoreOptIn?: boolean): void;
         function changeTelemetryOptInSetting(): Q.Promise<any>;


### PR DESCRIPTION
## Summary

Adding basic telemetry points to remotebuild. Telemetry is captured on server start and per build.

## Changes

* Added a new telemetry settings file for remotebuild.
* Added telemetry init/prompt to server start.
* Added telemetry after build complete.