### PR TITLE
Set ios-sim to a known good version

### DIFF
--- a/src/taco-remote-lib/package.json
+++ b/src/taco-remote-lib/package.json
@@ -36,7 +36,7 @@
         "should": "4.3.0"
     },
     "optionalDependencies": {
-        "ios-sim": "^5.0.2"
+        "ios-sim": "5.0.4"
     },
 
     "scripts": {


### PR DESCRIPTION
ios-sim has an issue with launching the simulator for a different devicetypeid when the simulator is already running. We are working around this by setting our dependency to a known good version.

ios-sim issue:
https://github.com/phonegap/ios-sim/issues/187