### PR TITLE
Fix for #259: Always prepare remote platforms

### DIFF
--- a/src/taco-remote-lib/common/builder.ts
+++ b/src/taco-remote-lib/common/builder.ts
@@ -139,7 +139,6 @@ class Builder {
 
     /**
      * Adds the platform if it isn't already present, or removes and re-adds it if the project Cordova version changed, or config.xml has a saved platform version that differs from the installed one.
-     * Prepares the platform afterwards.
      */
     private ensurePlatformAdded(): Q.Promise<any> {
         if (!fs.existsSync(path.join("platforms", this.currentBuild.buildPlatform))) {

--- a/src/taco-remote-lib/common/builder.ts
+++ b/src/taco-remote-lib/common/builder.ts
@@ -77,7 +77,7 @@ class Builder {
             .then(function (): Q.Promise<any> { return self.update_plugins(); })
             .then(function (): void { self.currentBuild.updateStatus(BuildInfo.BUILDING, "UpdatingPlatform", self.currentBuild.buildPlatform); process.send(self.currentBuild); })
             .then(function (): Q.Promise<any> { return self.beforePrepare(); })
-            .then(function (): Q.Promise<any> { return self.addOrPreparePlatform(); })
+            .then(function (): Q.Promise<any> { return self.addAndPreparePlatform(); })
             .then(function (): Q.Promise<any> { return self.afterPrepare(); })
             .then(function (): void { self.currentBuild.updateStatus(BuildInfo.BUILDING, "CopyingNativeOverrides"); process.send(self.currentBuild); })
             .then(function (): Q.Promise<any> { return self.prepareNativeOverrides(); })
@@ -127,7 +127,7 @@ class Builder {
         return Q({});
     }
 
-    private addOrPreparePlatform(): Q.Promise<any> {
+    private addAndPreparePlatform(): Q.Promise<any> {
         if (!fs.existsSync("platforms")) {
             fs.mkdirSync("platforms");
         }


### PR DESCRIPTION
The newer Cordova versions have stopped implicitly calling "prepare" when a platform is added. We must now always manually prepare platforms, whether we add the platform or not.

Fixes #259.