### PR TITLE
Bumping versions after publishing taco-remote-lib@1.3.0

### DIFF
--- a/src/taco-remote-multiplexer/dynamicDependencies.json
+++ b/src/taco-remote-multiplexer/dynamicDependencies.json
@@ -6,7 +6,7 @@
   },
   "preCordova540TacoRemoteLib": {
     "packageName": "taco-remote-lib",
-    "packageId": "taco-remote-lib@1.2.2"
+    "packageId": "taco-remote-lib@1.3.0"
   },
 
   "samplePackageInNpm": {

--- a/src/taco-remote-multiplexer/package.json
+++ b/src/taco-remote-multiplexer/package.json
@@ -1,7 +1,7 @@
 {
     "name": "taco-remote-multiplexer",
     "description": "A package to determine how to interact with a Cordova project, given some request parameters.",
-    "version": "1.2.6-dev",
+    "version": "1.2.8-dev",
     "author": {
         "name": "Microsoft Corporation",
         "email": "vscordovatools-admin@microsoft.com"


### PR DESCRIPTION
I'm about to publish taco-remote-lib@1.3.0 and taco-remote-multiplexer@1.2.7, so this updates master with the newest version numbers.