### PR TITLE
Updating TacoPackageLoader

### DIFF
--- a/src/taco-cli/cli/kit.ts
+++ b/src/taco-cli/cli/kit.ts
@@ -670,13 +670,7 @@ class Kit extends commands.TacoCommandBase {
         CordovaHelper.ensureCordovaVersionAcceptable(version);
         
         NpmHelper.view("cordova", ["versions"])
-            .then(function(result) {
-                var versions: any[] = [];
-                if (result) {
-                    var cordovaVersion = Object.keys(result)[0];
-                    versions = result[cordovaVersion].versions;
-                }
-
+            .then(function(versions: string[]) {
                 if (versions.indexOf(version) !== -1) {
                     deferred.resolve(version);
                 } else {

--- a/src/taco-cli/cli/kit.ts
+++ b/src/taco-cli/cli/kit.ts
@@ -661,24 +661,20 @@ class Kit extends commands.TacoCommandBase {
      * Validates whether the version string passed is a valid Cordova version
      */
     private static validateCliVersion(version: string): Q.Promise<any> {
-        var deferred: Q.Deferred<any> = Q.defer<any>();
-
         if (!semver.valid(version)) {
             return Q.reject(errorHelper.get(TacoErrorCodes.ErrorInvalidVersion, version, "cordova"));
         }
 
         CordovaHelper.ensureCordovaVersionAcceptable(version);
         
-        NpmHelper.view("cordova", ["versions"])
+        return NpmHelper.view("cordova", ["versions"])
             .then(function(versions: string[]) {
                 if (versions.indexOf(version) !== -1) {
-                    deferred.resolve(version);
+                    return version;
                 } else {
-                    deferred.reject(errorHelper.get(TacoErrorCodes.ErrorInvalidVersion, version, "cordova"));
+                    throw errorHelper.get(TacoErrorCodes.ErrorInvalidVersion, version, "cordova");
                 }
             });
-
-        return deferred.promise;
     }
 
     /**

--- a/src/taco-kits/test/validateMetadata.ts
+++ b/src/taco-kits/test/validateMetadata.ts
@@ -79,8 +79,7 @@ function validateComponent(packageName: string, version: string, src: string): Q
     // validate that version is correct
     if (version) {
         return NpmHelper.view(packageName, ["versions"])
-            .then(result => {
-                var versions = result[Object.keys(result)[0]].versions;
+            .then(versions => {
                 if (versions.indexOf(version) <= -1){
                     console.log(packageName + "@" + version);
                 }

--- a/src/taco-utils/npmHelper.ts
+++ b/src/taco-utils/npmHelper.ts
@@ -7,76 +7,69 @@
 
 "use strict";
 
-import npm = require("npm");
+import child_process = require("child_process");
+import os = require("os");
 import path = require("path");
 import Q = require("q");
-import nopt = require("nopt");
-import url = require("url");
-import semver = require("semver");
-
-var npmconf = require("npm/lib/config/core.js");
-var configDefs = npmconf.defs;
-var types = configDefs.types;
-var shorthands = configDefs.shorthands;
 
 import installLogLevel = require("./installLogLevel");
 import InstallLogLevel = installLogLevel.InstallLogLevel;
 
 module TacoUtility {
     export class NpmHelper {
-        private static runNpmCommand(npmCommand: string, args: string[], workingDirectory: string, commandFlags?: string[], logLevel?: InstallLogLevel, optionalArgs?: any): Q.Promise<any> {
-            var conf: any = {};
-            if (commandFlags) {
-                conf = nopt(types, shorthands, commandFlags, 0);
-            }
+        private static runNpmCommand(npmCommand: string, args: string[], workingDirectory: string, commandFlags?: string[], logLevel?: InstallLogLevel, silent: boolean = false): Q.Promise<string[]> {
 
-            if (logLevel && logLevel > 0) {
-                conf["logLevel"] = InstallLogLevel[logLevel];
-            }
+            const spawnArgs = [npmCommand].concat(args).concat(commandFlags || []);
 
-            var propertiesToSet: string[] = Object.keys(conf);
-            if (propertiesToSet.indexOf("argv") !== -1) {
-                propertiesToSet.splice(propertiesToSet.indexOf("argv"), 1);
-            }
+            const options = {
+                cwd: workingDirectory,
+                stdio: silent ? "pipe" : "inherit"
+            };
 
-            var oldValues: any = {};
-            return Q.nfcall(npm.load, {}).then(function() {
-                var configList = npm.config.list[0];
+            const npmExecutableName = "npm" + (os.platform() === "win32" ? ".cmd" : "");
 
-                propertiesToSet.forEach(prop => {
-                    oldValues[prop] = configList[prop];
-                    configList[prop] = conf[prop];
+            const npmProcess = child_process.spawn(npmExecutableName, spawnArgs, options);
+            const deferred = Q.defer<any>();
+
+            let stdout = "";
+            let stderr = "";
+
+            npmProcess.on("error", (err: Error) => deferred.reject(err));
+
+            if (silent) {
+                npmProcess.stdout.on("data", (data: Buffer) => {
+                    stdout += data.toString();
                 });
 
-                npm.prefix = workingDirectory || ".";
+                npmProcess.stderr.on("data", (data: Buffer) => {
+                    stderr += data.toString();
+                });
+            }
 
-                if (optionalArgs !== undefined) {
-                    return Q.ninvoke(npm.commands, npmCommand, args, optionalArgs);
+            npmProcess.on("exit", (code: number, signal: string) => {
+                if (code === 0) {
+                    deferred.resolve([stdout, stderr]);
                 }
-
-                return Q.ninvoke(npm.commands, npmCommand, args);
-            })
-            .finally(function(){
-                var configList = npm.config.list[0];
-
-                propertiesToSet.forEach(prop => {
-                    if (oldValues[prop] !== undefined) {
-                        configList[prop] = oldValues[prop];
-                    } else {
-                        delete configList[prop];
-                    }
-                });
             });
+
+            return deferred.promise;
+
         }
 
         public static install(packageId: string, workingDirectory?: string, commandFlags?: string[], logLevel?: InstallLogLevel): Q.Promise<any> {
             return NpmHelper.runNpmCommand("install", [packageId], workingDirectory, commandFlags, logLevel);
         }
 
+        // Returns the output of "npm view" as a javascript object
         public static view(packageId: string, fields?: string[], workingDirectory?: string, commandFlags?: string[], logLevel?: InstallLogLevel): Q.Promise<any> {
             var args = [packageId].concat(fields);
-            return NpmHelper.runNpmCommand("view", args, workingDirectory, commandFlags, logLevel, /*silent=*/true);
+            return NpmHelper.runNpmCommand("view", args, workingDirectory, commandFlags, logLevel, /*silent=*/true)
+                .then(([stdout, stderr]) => {
+                    return JSON.parse(stdout.replace(/'/g, '"'));
+                });
         }
+
+
     }
 }
 

--- a/src/taco-utils/npmHelper.ts
+++ b/src/taco-utils/npmHelper.ts
@@ -49,6 +49,8 @@ module TacoUtility {
             npmProcess.on("exit", (code: number, signal: string) => {
                 if (code === 0) {
                     deferred.resolve([stdout, stderr]);
+                } else {
+                    deferred.reject(code);
                 }
             });
 

--- a/src/taco-utils/package.json
+++ b/src/taco-utils/package.json
@@ -34,11 +34,8 @@
         "semver": "2.3.1",
         "unorm": "1.3.3",
         "windows-no-runnable": "0.0.6",
-		"npm": "^2.14.7",
         "winreg": "0.0.13",
-        "wrench": "^1.5.8",
-        "lodash": "^3.10.1",
-        "npm": "^2.14.7"
+        "wrench": "^1.5.8"
     },
     "devDependencies": {
         "mocha": "2.0.1",

--- a/src/taco-utils/tacoPackageLoader.ts
+++ b/src/taco-utils/tacoPackageLoader.ts
@@ -96,7 +96,7 @@ module TacoUtility {
         // Need to declare FILE_REGEX_PREFIX before FILE_URI_REGEX, but don't want to expose it outside the class
         private static FILE_REGEX_PREFIX: string = "file://";
         private static CORDOVA_NPM_PACKAGE_NAME: string = "cordova";
-        public static GIT_URI_REGEX: RegExp = /^http(s?)\\:\/\/.*|.*\.git$/;
+        public static GIT_URI_REGEX: RegExp = /(^http(s?):\/\/.*)|(.*\.git(#.*)?$)/;
         public static FILE_URI_REGEX: RegExp = new RegExp("^" + TacoPackageLoader.FILE_REGEX_PREFIX + ".*");
 
         public static mockForTests: TacoUtility.ITacoPackageLoader;


### PR DESCRIPTION
With this change we to back to invoking npm on the command line rather than via its unstable internal APIs. Also fixing an issue where valid github URLs with a #branch specifier were misunderstood.