### PR TITLE
Changing taco-remote-lib to use cordova-plugin-vs-taco-support

### DIFF
--- a/src/taco-remote-lib/common/builder.ts
+++ b/src/taco-remote-lib/common/builder.ts
@@ -60,7 +60,7 @@ class Builder {
             .then(function (): void { self.currentBuild.updateStatus(BuildInfo.BUILDING, "UpdatingPlatform", self.currentBuild.buildPlatform); process.send(self.currentBuild); })
             .then(function (): Q.Promise<any> { return self.beforePrepare(); })
             .then(function (): Q.Promise<any> { return self.addPlatform(); })
-            .then(function (): Q.Promise<any> { return self.build_platform(); })
+            .then(function (): Q.Promise<any> { return self.buildPlatform(); })
             .then(function (): Q.Promise<any> { return self.afterCompile(); })
             .then(function (): void { self.currentBuild.updateStatus(BuildInfo.BUILDING, "PackagingNativeApp"); process.send(self.currentBuild); })
             .then(function (): Q.Promise<any> { return isDeviceBuild ? self.package() : Q({}); })
@@ -256,7 +256,7 @@ class Builder {
             });
     }
 
-    private build_platform(): Q.Promise<any> {
+    private buildPlatform(): Q.Promise<any> {
         Logger.log("cordova build " + this.currentBuild.buildPlatform);
         //var opts: string [] = (this.currentBuild.options.length > 0) ? [this.currentBuild.options, configuration] : [configuration];
         var opts: Cordova.ICordova540BuildOptions = {};


### PR DESCRIPTION
To resolve issues with before/after build hooks not running, this commit removes some of the workarounds for outdated problems, and changes the implementation of res/native functionality to use the cordova-plugin-vs-taco-support.