### PR TITLE
Increasing HTTP connection timeouts

### DIFF
--- a/src/remotebuild/lib/server.ts
+++ b/src/remotebuild/lib/server.ts
@@ -216,6 +216,9 @@ class Server {
         return Q(http.createServer(app)).
             then(function (svr: http.Server): Q.Promise<http.Server> {
                 var deferred: Q.Deferred<http.Server> = Q.defer<http.Server>();
+		// Increase the timeout to work around disconnects on larger uploads
+		// https://blog.cloudflare.com/the-curious-case-of-slow-downloads/
+		svr.setTimeout(5*60*1000);
                 svr.on("error", function (err: any): void {
                     deferred.reject(Server.friendlyServerListenError(err, conf));
                 });
@@ -288,6 +291,9 @@ class Server {
             }).
             then(function (svr: https.Server): Q.Promise<https.Server> {
                 var deferred: Q.Deferred<https.Server> = Q.defer<https.Server>();
+		// Increase the timeout to work around disconnects on larger uploads
+		// https://blog.cloudflare.com/the-curious-case-of-slow-downloads/
+		svr.setTimeout(5*60*1000);
                 svr.on("error", function (err: any): void {
                     if (generatedNewCerts) {
                         HostSpecifics.hostSpecifics.removeAllCertsSync(conf);

--- a/src/remotebuild/lib/server.ts
+++ b/src/remotebuild/lib/server.ts
@@ -216,9 +216,9 @@ class Server {
         return Q(http.createServer(app)).
             then(function (svr: http.Server): Q.Promise<http.Server> {
                 var deferred: Q.Deferred<http.Server> = Q.defer<http.Server>();
-		// Increase the timeout to work around disconnects on larger uploads
-		// https://blog.cloudflare.com/the-curious-case-of-slow-downloads/
-		svr.setTimeout(5*60*1000);
+                // Increase the timeout to work around disconnects on larger uploads
+                // https://blog.cloudflare.com/the-curious-case-of-slow-downloads/
+                svr.setTimeout(5*60*1000);
                 svr.on("error", function (err: any): void {
                     deferred.reject(Server.friendlyServerListenError(err, conf));
                 });
@@ -291,9 +291,9 @@ class Server {
             }).
             then(function (svr: https.Server): Q.Promise<https.Server> {
                 var deferred: Q.Deferred<https.Server> = Q.defer<https.Server>();
-		// Increase the timeout to work around disconnects on larger uploads
-		// https://blog.cloudflare.com/the-curious-case-of-slow-downloads/
-		svr.setTimeout(5*60*1000);
+                // Increase the timeout to work around disconnects on larger uploads
+                // https://blog.cloudflare.com/the-curious-case-of-slow-downloads/
+                svr.setTimeout(5*60*1000);
                 svr.on("error", function (err: any): void {
                     if (generatedNewCerts) {
                         HostSpecifics.hostSpecifics.removeAllCertsSync(conf);


### PR DESCRIPTION
When uploading larger projects, some connections would be terminated unexpectedly.
I believe that it is related to https://blog.cloudflare.com/the-curious-case-of-slow-downloads/
and so I have increased the timout to work around that. If it is the linked issue, then a 5 minute timeout should be sufficient to allow arbitrary uploads.

Fixes #291